### PR TITLE
improve unit tests

### DIFF
--- a/scripts/quick_start.py
+++ b/scripts/quick_start.py
@@ -1,18 +1,41 @@
 import sys
 sys.path.insert(0,'src/geometricconvolutions/')
 
-import geometric as geom
+from geometric import ktensor
 import jax.numpy as jnp
 import jax.random as random
 
 key = random.PRNGKey(0)
 
-image = geom.geometric_image(random.uniform(key, shape=(5,5)), 0, 2)
-filter_image = geom.geometric_filter.zeros(3, 0, 0, 2)
-filter_image[0,0] = filter_image[0,2] = filter_image[2,0] = filter_image[2,2] = 1
-# print(image)
-print(filter_image.data)
-print(image.data)
-convolved_image = image.convolve_with(filter_image)
-print(convolved_image.data)
+# image = geom.geometric_image(random.uniform(key, shape=(5,5,5,3,3,3)), 0, 3)
+# contracted_image0_1 = image.levi_civita_contract((0,1))
+# print(contracted_image0_1.data)
+# print(contracted_image0_1.data.shape)
+# contracted_image0_2 = image.levi_civita_contract((0,2))
+# contracted_image1_2 = image.levi_civita_contract((1,2))
+# contracted_image1_0 = image.levi_civita_contract((1,0))
+# print()
+# print((contracted_image1_0.data == contracted_image0_1.data).all())
+# print(contracted_image.data.shape)
 
+a = ktensor(jnp.array([0,1,3]), 0, 3)
+b = ktensor(jnp.array([1,2,-1]), 0, 3)
+
+ab = a*b
+print(ab.data)
+cross = ab.levi_civita_contract((0,1))
+print(cross.data)
+
+
+
+# filter_image = geom.geometric_filter.zeros(3, 0, 0, 2)
+# filter_image[0,0] = filter_image[0,2] = filter_image[2,0] = filter_image[2,2] = 1
+# # print(image)
+# print(filter_image.data)
+# print(image.data)
+# convolved_image = image.convolve_with(filter_image)
+# print(convolved_image.data)
+
+
+
+# print(geom.get_levi_civita_symbol(4))

--- a/tests/test_geometric_image.py
+++ b/tests/test_geometric_image.py
@@ -3,7 +3,7 @@ sys.path.insert(0,'src/geometricconvolutions/')
 
 import math
 
-from geometric import geometric_image
+from geometric import geometric_image, geometric_filter
 import pytest
 import jax.numpy as jnp
 from jax import random
@@ -61,6 +61,11 @@ class TestGeometricImage:
         image2 = image1.copy()
 
         assert type(image1) == type(image2)
+        assert (image1.data == image2.data).all()
+        assert image1.parity == image2.parity
+        assert image1.D == image2.D
+        assert image1.k == image2.k
+        assert image1.N == image2.N
         assert image1 != image2
 
     def testAdd(self):
@@ -95,6 +100,66 @@ class TestGeometricImage:
         image5 = geometric_image(jnp.ones((20,20,2), dtype=int), 0, 2)
         with pytest.raises(AssertionError): #N not equal
             result = image1 + image5
+
+    def testMul(self):
+        image1 = geometric_image(2*jnp.ones((3,3), dtype=int), 0, 2)
+        image2 = geometric_image(5*jnp.ones((3,3), dtype=int), 0, 2)
+
+        mult1_2 = image1 * image2
+        assert mult1_2.k == 0
+        assert mult1_2.parity == 0
+        assert mult1_2.D == image1.D == image2.D
+        assert mult1_2.N == image1.N == image1.N
+        assert (mult1_2.data == 10*jnp.ones((3,3))).all()
+        assert (mult1_2.data == (image2 * image1).data).all()
+
+        image3 = geometric_image(jnp.arange(18).reshape(3,3,2), 0, 2)
+        mult1_3 = image1 * image3
+        assert mult1_3.k == image1.k + image3.k == 1
+        assert mult1_3.parity == (image1.parity + image3.parity) % 2 == 0
+        assert mult1_3.D == image1.D == image3.D
+        assert mult1_3.N == image1.N == image3.N
+        assert (mult1_3.data == jnp.array(
+            [
+                [[0,2],[4,6],[8,10]],
+                [[12,14],[16,18],[20,22]],
+                [[24,26],[28,30],[32,34]],
+            ],
+        dtype=int)).all()
+
+        image4 = geometric_image(jnp.arange(18).reshape((3,3,2)), 1, 2)
+        mult3_4 = image3 * image4
+        assert mult3_4.k == image3.k + image3.k == 2
+        assert mult3_4.parity == (image3.parity + image4.parity) % 2 == 1
+        assert mult3_4.D == image3.D == image4.D
+        assert mult3_4.N == image3.N == image4.N
+        assert (mult3_4.data == jnp.array(
+            [
+                [
+                    (image3.ktensor((0,0))*image4.ktensor((0,0))).data, #relies on our tests for ktensor multiplication
+                    (image3.ktensor((0,1))*image4.ktensor((0,1))).data,
+                    (image3.ktensor((0,2))*image4.ktensor((0,2))).data,
+                ],
+                [
+                    (image3.ktensor((1,0))*image4.ktensor((1,0))).data,
+                    (image3.ktensor((1,1))*image4.ktensor((1,1))).data,
+                    (image3.ktensor((1,2))*image4.ktensor((1,2))).data,
+                ],
+                [
+                    (image3.ktensor((2,0))*image4.ktensor((2,0))).data,
+                    (image3.ktensor((2,1))*image4.ktensor((2,1))).data,
+                    (image3.ktensor((2,2))*image4.ktensor((2,2))).data,
+                ],
+            ],
+        dtype=int)).all()
+
+        image5 = geometric_image(jnp.ones((10,10)), 0, 2)
+        with pytest.raises(AssertionError): #mismatched N
+            image5 * image1
+
+        image6 = geometric_image(jnp.ones((3,3,3)), 0, 3)
+        with pytest.raises(AssertionError): #mismatched D
+            image6 * image1
 
     def testTimeScalar(self):
         image1 = geometric_image(jnp.ones((10,10,2), dtype=int), 0, 2)
@@ -148,10 +213,86 @@ class TestGeometricImage:
                 assert jnp.linalg.norm(pixel) < (1 + TINY)
 
 
-    # def testConvolveWith(self):
+    def testConvSubimage(self):
+        image1 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)
+        filter1 = geometric_filter(jnp.zeros(25).reshape((5,5)), 0, 2)
+        subimage1 = image1.conv_subimage((0,0), filter1)
+        assert subimage1.shape() == (5,5)
+        assert subimage1.D == image1.D
+        assert subimage1.N == filter1.N
+        assert subimage1.k == image1.k
+        assert subimage1.parity == image1.parity
+        assert (subimage1.data == jnp.array(
+            [
+                [18,19,15,16,17],
+                [23,24,20,21,22],
+                [3,4,0,1,2],
+                [8,9,5,6,7],
+                [13,14,10,11,12],
+            ],
+        dtype=int)).all()
 
+        subimage2 = image1.conv_subimage((4,4), filter1)
+        assert subimage2.shape() == (5,5)
+        assert subimage2.D == image1.D
+        assert subimage2.N == filter1.N
+        assert subimage2.k == image1.k
+        assert subimage2.parity == image1.parity
+        assert (subimage2.data == jnp.array(
+            [
+                [12,13,14,10,11],
+                [17,18,19,15,16],
+                [22,23,24,20,21],
+                [2,3,4,0,1],
+                [7,8,9,5,6],
+            ],
+        dtype=int)).all()
 
+        image2 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)*geometric_image(jnp.ones((5,5,2)), 0, 2)
+        subimage3 = image2.conv_subimage((0,0), filter1)
+        assert subimage3.shape() == (5,5,2)
+        assert subimage3.D == image2.D
+        assert subimage3.N == filter1.N
+        assert subimage3.k == image2.k
+        assert subimage3.parity == image2.parity
+        assert (subimage3.data == jnp.array(
+            [
+                [x*jnp.array([1,1]) for x in [18,19,15,16,17]],
+                [x*jnp.array([1,1]) for x in [23,24,20,21,22]],
+                [x*jnp.array([1,1]) for x in [3,4,0,1,2]],
+                [x*jnp.array([1,1]) for x in [8,9,5,6,7]],
+                [x*jnp.array([1,1]) for x in [13,14,10,11,12]],
+            ],
+        dtype=int)).all()
 
+    def testConvolveWithK0(self):
+        #did these out by hand, hopefully, my arithmetic is correct...
+        image1 = geometric_image(jnp.array([[2,1,0], [0,0,-3], [2,0,1]], dtype=int), 0, 2)
+        filter_image = geometric_filter(jnp.array([[1,0,1], [0,0,0], [1,0,1]], dtype=int), 0, 2)
+
+        convolved_image = image1.convolve_with(filter_image)
+        assert convolved_image.D == image1.D
+        assert convolved_image.N == image1.N
+        assert convolved_image.k == image1.k + filter_image.k
+        assert convolved_image.parity == (image1.parity + filter_image.parity) % 2
+        assert (convolved_image.data == jnp.array([[-2,0,2], [2,5,5], [-2,-1,3]], dtype=int)).all()
+
+        key = random.PRNGKey(0)
+        image2 = geometric_image(jnp.floor(10*random.uniform(key, shape=(5,5))), 0, 2)
+        convolved_image2 = image2.convolve_with(filter_image)
+        assert convolved_image2.D == image2.D
+        assert convolved_image2.N == image2.N
+        assert convolved_image2.k == image2.k + filter_image.k
+        assert convolved_image2.parity == (image2.parity + filter_image.parity) % 2
+        assert (convolved_image2.data == jnp.array(
+            [
+                [16,9,16,11,10],
+                [15,19,15,13,28],
+                [17,19,15,16,17],
+                [16,12,13,13,18],
+                [8,23,11,13,29],
+            ],
+        dtype=int)).all()
 
 
 

--- a/tests/test_ktensor.py
+++ b/tests/test_ktensor.py
@@ -2,6 +2,7 @@ import sys
 sys.path.insert(0,'src/geometricconvolutions/')
 
 import math
+import itertools as it
 
 from geometric import geometric_image, ktensor
 import pytest
@@ -10,88 +11,109 @@ from jax import random
 
 TINY = 1.e-5
 
+def levi_civita_contract_old(ktensor_obj, index):
+        assert ktensor_obj.D in [2, 3] # BECAUSE WE SUCK
+        assert (ktensor_obj.k + 1) >= ktensor_obj.D # so we have enough indices work on
+        if ktensor_obj.D == 2 and not isinstance(index, tuple):
+            index = (index,)
+
+        if ktensor_obj.D == 2:
+            index = index[0]
+            otherdata = jnp.zeros_like(ktensor_obj.data)
+            otherdata = otherdata.at[..., 0].set(1. * jnp.take(ktensor_obj.data, 1, axis=index))
+            otherdata = otherdata.at[..., 1].set(-1. * jnp.take(ktensor_obj.data, 0, axis=index))
+            return ktensor(otherdata, ktensor_obj.parity + 1, ktensor_obj.D)
+        if ktensor_obj.D == 3:
+            assert len(index) == 2
+            i, j = index
+            assert i < j
+            otherdata = jnp.zeros_like(ktensor_obj.data[..., 0])
+            otherdata = otherdata.at[..., 0].set(jnp.take(jnp.take(ktensor_obj.data, 2, axis=j), 1, axis=i) \
+                              - jnp.take(jnp.take(ktensor_obj.data, 1, axis=j), 2, axis=i))
+            otherdata = otherdata.at[..., 1].set(jnp.take(jnp.take(ktensor_obj.data, 0, axis=j), 2, axis=i) \
+                              - jnp.take(jnp.take(ktensor_obj.data, 2, axis=j), 0, axis=i))
+            otherdata = otherdata.at[..., 2].set(jnp.take(jnp.take(ktensor_obj.data, 1, axis=j), 0, axis=i) \
+                              - jnp.take(jnp.take(ktensor_obj.data, 0, axis=j), 1, axis=i))
+            return ktensor(otherdata, ktensor_obj.parity + 1, ktensor_obj.D)
+        return
+
 class TestGeometricImage:
 
     def testConstructor(self):
         #note we are not actually relying on randomness in this function, just filling values
-        # key = random.PRNGKey(0)
+        key = random.PRNGKey(0)
 
-        image1 = ktensor(jnp.array([1,1]), 0, 2)
+        image1 = ktensor(jnp.array([5]), 0, 2)
+        assert image1.data.shape == (1,)
+        assert image1.k == 0
+        assert image1.parity == 0
 
-        assert image1.data.shape == (2,)
-        assert image1.D == 2
-        assert image1.k == 1
+        image2 = ktensor(jnp.array([1,1]), 1, 2)
+        assert image2.data.shape == (2,)
+        assert image2.D == 2
+        assert image2.k == 1
+        assert image2.parity == 1
 
-        # image2 = geometric_image(random.uniform(key, shape=(10,10,2)), 0, 2)
-        # assert image2.data.shape == (10,10,2)
-        # assert image2.D == 2
-        # assert image2.k == 1
+        image3 = ktensor(random.uniform(key, shape=(2,2)), 3, 2)
+        assert image3.data.shape == (2,2)
+        assert image3.D == 2
+        assert image3.k == 2
+        assert image3.parity == 1
 
-        # image3 = geometric_image(random.uniform(key, shape=(10,10,2,2,2)), 3, 2)
-        # assert image3.data.shape == (10,10,2,2,2)
-        # assert image3.k == 3
-        # assert image3.parity == 1
+        image4 = ktensor(random.uniform(key, shape=(2,2,2)), 1, 2)
+        assert image4.data.shape == (2,2,2)
+        assert image4.D == 2
+        assert image4.k == 3
+        assert image4.parity == 1
 
-        # #D does not match dimensions
-        # with pytest.raises(AssertionError):
-        #     geometric_image(random.uniform(key, shape=(10,10)), 0, 3)
+        #D does not match dimensions
+        with pytest.raises(AssertionError):
+            ktensor(random.uniform(key, shape=(10,10)), 0, 3)
 
-        # #non square
-        # with pytest.raises(AssertionError):
-        #     geometric_image(random.uniform(key, shape=(10,20)), 0, 3)
+        #non square
+        with pytest.raises(AssertionError):
+            geometric_image(random.uniform(key, shape=(10,20)), 0, 10)
 
-        # #side length of pixel tensors does not match D
-        # with pytest.raises(AssertionError):
-        #     geometric_image(random.uniform(key, shape=(10,10,3,3)), 0, 2)
+    def testAdd(self):
+        ktensor1 = ktensor(jnp.ones((2,2,2), dtype=int), 0, 2)
+        ktensor2 = ktensor(5*jnp.ones((2,2,2), dtype=int), 0, 2)
 
-    # def testAdd(self):
-    #     image1 = geometric_image(jnp.ones((10,10,2), dtype=int), 0, 2)
-    #     image2 = geometric_image(5*jnp.ones((10,10,2), dtype=int), 0, 2)
-    #     float_image = geometric_image(3.4*jnp.ones((10,10,2)), 0, 2)
+        result = ktensor1 + ktensor2
+        assert (result.data == 6).all()
+        assert result.parity == ktensor1.parity == ktensor2.parity
+        assert result.D == ktensor1.D == ktensor2.D
+        assert result.k == ktensor1.k == ktensor2.k
 
-    #     result = image1 + image2
-    #     assert (result.data == 6).all()
-    #     assert result.parity == 0
-    #     assert result.D == 2
-    #     assert result.k == 1
-    #     assert result.N == 10
+        assert (ktensor1.data == 1).all()
+        assert (ktensor2.data == 5).all()
 
-    #     assert (image1.data == 1).all()
-    #     assert (image2.data == 5).all()
+        ktensor3 = ktensor(jnp.ones((3,3,3)), 0, 3)
+        ktensor4 = ktensor(jnp.ones((2,2,2)), 1, 2)
+        ktensor5 = ktensor(jnp.ones((2,2)), 0, 2)
 
-    #     result = image1 + float_image
-    #     assert (result.data == 4.4).all()
+        with pytest.raises(AssertionError): #D not equal
+            result = ktensor1 + ktensor3
 
-    #     image3 = geometric_image(jnp.ones((10,10,10,3), dtype=int), 0, 3)
-    #     with pytest.raises(AssertionError): #D not equal
-    #         result = image1 + image3
+        with pytest.raises(AssertionError): #parity not equal
+            result = ktensor1 + ktensor4
 
-    #     image4 = geometric_image(jnp.ones((10,10,2), dtype=int), 1, 2)
-    #     with pytest.raises(AssertionError): #parity not equal
-    #         result = image1 + image4
+        with pytest.raises(AssertionError): #k not equal
+            result = ktensor1 + ktensor5 #k
 
-    #     with pytest.raises(AssertionError):
-    #         result = image3 + image4 #D and parity not equal
+    def testTimeScalar(self):
+        ktensor1 = ktensor(jnp.ones((2,2,2), dtype=int), 0, 2)
+        assert (ktensor1.data == 1).all()
 
-    #     image5 = geometric_image(jnp.ones((20,20,2), dtype=int), 0, 2)
-    #     with pytest.raises(AssertionError): #N not equal
-    #         result = image1 + image5
+        result = ktensor1.times_scalar(5)
+        assert (result.data == 5).all()
+        assert result.parity == ktensor1.parity
+        assert result.D == ktensor1.D
+        assert result.k == ktensor1.k
+        assert (ktensor1.data == 1).all() #original is unchanged
 
-    # def testTimeScalar(self):
-    #     image1 = geometric_image(jnp.ones((10,10,2), dtype=int), 0, 2)
-    #     assert (image1.data == 1).all()
-
-    #     result = image1.times_scalar(5)
-    #     assert (result.data == 5).all()
-    #     assert result.parity == image1.parity
-    #     assert result.D == image1.D
-    #     assert result.k == image1.k
-    #     assert result.N == image1.N
-    #     assert (image1.data == 1).all() #original is unchanged
-
-    #     result2 = image1.times_scalar(3.4)
-    #     assert (result2.data == 3.4).all()
-    #     assert (image1.data == 1).all()
+        result2 = ktensor1.times_scalar(3.4)
+        assert (result2.data == 3.4).all()
+        assert (ktensor1.data == 1).all()
 
     # def testGetItem(self):
     #     #note we are not actually relying on randomness in this function, just filling values
@@ -129,8 +151,43 @@ class TestGeometricImage:
     #             assert jnp.linalg.norm(pixel) < (1 + TINY)
 
 
+    def testDotProduct(self):
+        a = ktensor(jnp.array([0,1,3]), 0, 3)
+        b = ktensor(jnp.array([1,2,-1]), 0, 3)
 
+        ab = (a*b)
+        dot = ab.contract(0,1)
+        assert dot.data == -1
+        assert dot.parity == ab.parity == a.parity == b.parity #in this case, since a and b have parity 1
+        assert dot.D == ab.D
+        assert dot.k == ab.k - 2
 
+    def testCrossProduct(self):
+        a = ktensor(jnp.array([0,1,3]), 0, 3)
+        b = ktensor(jnp.array([1,2,-1]), 0, 3)
+
+        ab = a*b
+        cross = ab.levi_civita_contract((0,1))
+        assert (cross.data == jnp.array([-7,3,-1])).all()
+        assert cross.parity == (ab.parity + 1) % 2
+        assert cross.D == ab.D == a.D == b.D
+        assert cross.k == (ab.k - ab.D + 2)
+
+    def testLeviCivitaContract(self):
+        key = random.PRNGKey(0)
+
+        for D in range(2,4):
+            for k in range(D-1, D+2):
+                key, subkey = random.split(key)
+                ktensor1 = ktensor(random.uniform(key, shape=k*(D,)), 0, D)
+
+                for indices in it.combinations(range(k), D-1):
+                    print(D,k,indices)
+                    ktensor1_contracted = ktensor1.levi_civita_contract(indices)
+                    assert (ktensor1_contracted.data == levi_civita_contract_old(ktensor1, indices).data).all()
+                    assert ktensor1_contracted.k == (ktensor1.k - ktensor1.D + 2)
+                    assert ktensor1_contracted.parity == (ktensor1.parity + 1) % 2
+                    assert ktensor1_contracted.D == ktensor1.D
 
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,28 @@
+import sys
+sys.path.insert(0,'src/geometricconvolutions/')
+
+from geometric import levi_civita_symbol
+import pytest
+import jax.numpy as jnp
+
+TINY = 1.e-5
+
+class TestMisc:
+
+    def testLeviCivitaSymbol(self):
+        with pytest.raises(AssertionError):
+            levi_civita_symbol.get(1)
+
+        assert (levi_civita_symbol.get(2) == jnp.array([[0, 1], [-1, 0]], dtype=int)).all()
+        assert (levi_civita_symbol.get(3) == jnp.array(
+            [
+                [[0,0,0], [0,0,1], [0,-1,0]],
+                [[0,0,-1], [0,0,0], [1,0,0]],
+                [[0,1,0], [-1,0,0], [0,0,0]],
+            ],
+            dtype=int)).all()
+
+        assert levi_civita_symbol.get(2) is levi_civita_symbol.get(2) #test that we aren't remaking them
+
+
+


### PR DESCRIPTION
## Changes
- quick_start.py is currently scratch space, ignore
- make a mini Levi-Civita class to store the Levi-Civita symbol statically so we aren't constantly re-computing it
- rewrite Levi-Civita contraction based on the definition, may not be optimized but it can handle all different sizes
- rewrite convolution, implement the hash_list function for ease of hashing a grid of indices correctly
- expand test suite, move old levi-civita contraction to test file and use it to confirm that they agree on D=2,3 examples

## Testing
- large expanded unit test suite

## Doc Changes
- none
