### PR TITLE
Gregory convolution efficiency

### DIFF
--- a/notebooks/how_many_linear_operations.ipynb
+++ b/notebooks/how_many_linear_operations.ipynb
@@ -18,6 +18,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f7f72aef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0,'../src/geometricconvolutions/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "cb453713",
    "metadata": {},
    "outputs": [],
@@ -25,6 +36,7 @@
     "import itertools as it\n",
     "import numpy as np\n",
     "import geometric as geom\n",
+    "import utils\n",
     "import finufft\n",
     "import pylab as plt\n",
     "%load_ext autoreload\n",
@@ -41,26 +53,6 @@
     "D = 2\n",
     "group_operators = geom.make_all_operators(D)\n",
     "print(len(group_operators))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fd529235",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "geom.test_group(group_operators)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f450d53e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "geom.test_group_actions(group_operators)"
    ]
   },
   {
@@ -96,7 +88,7 @@
     "paritysign = {0: \"+\", 1: \"-\"}\n",
     "for key in allfilters.keys():\n",
     "    D, M, k, parity = key\n",
-    "    fig = geom.plot_filters(allfilters[key], names[key], maxn[(D, M)])"
+    "    fig = utils.plot_filters(allfilters[key], names[key], maxn[(D, M)])"
    ]
   },
   {
@@ -140,7 +132,7 @@
    "outputs": [],
    "source": [
     "if D == 2:\n",
-    "    fig = geom.plot_image(vector_image)"
+    "    fig = utils.plot_image(vector_image)"
    ]
   },
   {
@@ -222,7 +214,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datablock = np.array([im.unpack().flatten() for im in v_images])\n",
+    "datablock = np.array([im.data.flatten() for im in v_images])\n",
     "print(datablock.shape)\n",
     "u, s, v = np.linalg.svd(datablock)\n",
     "print(\"there are\", np.sum(s > geom.TINY), \"different images\")"

--- a/scripts/quick_start.py
+++ b/scripts/quick_start.py
@@ -7,14 +7,19 @@ import jax.numpy as jnp
 import jax.random as random
 
 def testIK0_FK1():
+    """
+    Convolve with where the input is k=0, and the filter is k=1
+    """
     image1 = geom.geometric_image(jnp.array([[2,1,0], [0,0,-3], [2,0,1]], dtype=int), 0, 2)
     filter_image = geom.geometric_filter(jnp.array([
         [[0,0], [0,1], [0,0]],
         [[-1,0],[0,0], [1,0]],
         [[0,0], [0,-1],[0,0]],
-    ], dtype=int), 0, 2) #this is an invariant filter, hopefully not relevant?
+    ], dtype=int), 0, 2) #this is an invariant filter, hopefully not a problem?
 
     convolved_image = image1.convolve_with(filter_image)
+    # print(convolved_image.data)
+
     assert convolved_image.D == image1.D
     assert convolved_image.N == image1.N
     assert convolved_image.k == image1.k + filter_image.k
@@ -24,6 +29,35 @@ def testIK0_FK1():
         [[3,0],[-3,1],[0,-1]],
         [[-1,-2],[-1,-1],[2,-3]]
     ], dtype=int)).all()
+
+def testIK0_FK0():
+    #did these out by hand, hopefully, my arithmetic is correct...
+    image1 = geom.geometric_image(jnp.array([[2,1,0], [0,0,-3], [2,0,1]], dtype=int), 0, 2)
+    filter_image = geom.geometric_filter(jnp.array([[1,0,1], [0,0,0], [1,0,1]], dtype=int), 0, 2)
+
+    convolved_image = image1.convolve_with(filter_image)
+    assert convolved_image.D == image1.D
+    assert convolved_image.N == image1.N
+    assert convolved_image.k == image1.k + filter_image.k
+    assert convolved_image.parity == (image1.parity + filter_image.parity) % 2
+    assert (convolved_image.data == jnp.array([[-2,0,2], [2,5,5], [-2,-1,3]], dtype=int)).all()
+
+    key = random.PRNGKey(0)
+    image2 = geom.geometric_image(jnp.floor(10*random.uniform(key, shape=(5,5))), 0, 2)
+    convolved_image2 = image2.convolve_with(filter_image)
+    assert convolved_image2.D == image2.D
+    assert convolved_image2.N == image2.N
+    assert convolved_image2.k == image2.k + filter_image.k
+    assert convolved_image2.parity == (image2.parity + filter_image.parity) % 2
+    assert (convolved_image2.data == jnp.array(
+        [
+            [16,9,16,11,10],
+            [15,19,15,13,28],
+            [17,19,15,16,17],
+            [16,12,13,13,18],
+            [8,23,11,13,29],
+        ],
+    dtype=int)).all()
 
 def testUniqueInvariantFilters():
     # ensure that all the filters are actually invariant
@@ -56,6 +90,22 @@ def testUniqueInvariantFilters():
 
 # testUniqueInvariantFilters()
 
+testIK0_FK0()
 testIK0_FK1()
+
+# key = random.PRNGKey(0)
+
+# #N=10, D=2, parity=0, k=2
+# rand_img = geom.geometric_image(random.uniform(key, shape=(1000,1000,2)), parity=0, D=2)
+
+# #N=3, D=2, parity=0, k=0
+# geom_filter = geom.geometric_filter(jnp.array([[[1,1], [0,0], [1,1]], [[0,0],[0,0],[0,0]], [[1,1],[0,0],[1,1]]]), parity=0, D=2)
+
+# convolved_img = rand_img.convolve_with(geom_filter)
+# # print(convolved_img.data)
+# print(convolved_img.shape())
+
+
+
 
 

--- a/scripts/quick_start.py
+++ b/scripts/quick_start.py
@@ -59,6 +59,35 @@ def testIK0_FK0():
         ],
     dtype=int)).all()
 
+def testConvolveWithRandoms():
+        # this test uses convolve_with_slow to test convolve_with, possibly the blind leading the blind
+        key = random.PRNGKey(0)
+        N=3
+
+        for D in [2,3]:
+            for k_img in range(3):
+                key, subkey = random.split(key)
+                image = geom.geometric_image(random.uniform(subkey, shape=((N,)*D + (D,)*k_img)), 0, D)
+
+                for k_filter in range(3):
+                    key, subkey = random.split(key)
+                    geom_filter = geom.geometric_filter(random.uniform(subkey, shape=((3,)*D + (D,)*k_filter)), 0, D)
+
+                    convolved_image = image.convolve_with(geom_filter)
+                    convolved_image_slow = image.convolve_with_slow(geom_filter)
+
+                    assert convolved_image.D == convolved_image_slow.D == image.D
+                    assert convolved_image.N == convolved_image_slow.N == image.N
+                    assert convolved_image.k == convolved_image_slow.k == image.k + geom_filter.k
+                    assert convolved_image.parity == convolved_image_slow.parity == (image.parity + geom_filter.parity) %2
+
+                    # print(image.shape())
+                    # print(geom_filter.shape())
+                    # print(convolved_image.shape())
+                    # print(convolved_image_slow.shape())
+                    print(D,k_img,k_filter)
+                    assert jnp.allclose(convolved_image.data, convolved_image_slow.data)
+
 def testUniqueInvariantFilters():
     # ensure that all the filters are actually invariant
     key = random.PRNGKey(0)
@@ -90,8 +119,10 @@ def testUniqueInvariantFilters():
 
 # testUniqueInvariantFilters()
 
-testIK0_FK0()
-testIK0_FK1()
+# testIK0_FK0()
+# testIK0_FK1()
+
+testConvolveWithRandoms()
 
 # key = random.PRNGKey(0)
 

--- a/scripts/quick_start.py
+++ b/scripts/quick_start.py
@@ -18,7 +18,6 @@ def testIK0_FK1():
     ], dtype=int), 0, 2) #this is an invariant filter, hopefully not a problem?
 
     convolved_image = image1.convolve_with(filter_image)
-    # print(convolved_image.data)
 
     assert convolved_image.D == image1.D
     assert convolved_image.N == image1.N
@@ -30,63 +29,6 @@ def testIK0_FK1():
         [[-1,-2],[-1,-1],[2,-3]]
     ], dtype=int)).all()
 
-def testIK0_FK0():
-    #did these out by hand, hopefully, my arithmetic is correct...
-    image1 = geom.geometric_image(jnp.array([[2,1,0], [0,0,-3], [2,0,1]], dtype=int), 0, 2)
-    filter_image = geom.geometric_filter(jnp.array([[1,0,1], [0,0,0], [1,0,1]], dtype=int), 0, 2)
-
-    convolved_image = image1.convolve_with(filter_image)
-    assert convolved_image.D == image1.D
-    assert convolved_image.N == image1.N
-    assert convolved_image.k == image1.k + filter_image.k
-    assert convolved_image.parity == (image1.parity + filter_image.parity) % 2
-    assert (convolved_image.data == jnp.array([[-2,0,2], [2,5,5], [-2,-1,3]], dtype=int)).all()
-
-    key = random.PRNGKey(0)
-    image2 = geom.geometric_image(jnp.floor(10*random.uniform(key, shape=(5,5))), 0, 2)
-    convolved_image2 = image2.convolve_with(filter_image)
-    assert convolved_image2.D == image2.D
-    assert convolved_image2.N == image2.N
-    assert convolved_image2.k == image2.k + filter_image.k
-    assert convolved_image2.parity == (image2.parity + filter_image.parity) % 2
-    assert (convolved_image2.data == jnp.array(
-        [
-            [16,9,16,11,10],
-            [15,19,15,13,28],
-            [17,19,15,16,17],
-            [16,12,13,13,18],
-            [8,23,11,13,29],
-        ],
-    dtype=int)).all()
-
-def testConvolveWithRandoms():
-        # this test uses convolve_with_slow to test convolve_with, possibly the blind leading the blind
-        key = random.PRNGKey(0)
-        N=3
-
-        for D in [2,3]:
-            for k_img in range(3):
-                key, subkey = random.split(key)
-                image = geom.geometric_image(random.uniform(subkey, shape=((N,)*D + (D,)*k_img)), 0, D)
-
-                for k_filter in range(3):
-                    key, subkey = random.split(key)
-                    geom_filter = geom.geometric_filter(random.uniform(subkey, shape=((3,)*D + (D,)*k_filter)), 0, D)
-
-                    convolved_image = image.convolve_with(geom_filter)
-                    convolved_image_slow = image.convolve_with_slow(geom_filter)
-
-                    assert convolved_image.D == convolved_image_slow.D == image.D
-                    assert convolved_image.N == convolved_image_slow.N == image.N
-                    assert convolved_image.k == convolved_image_slow.k == image.k + geom_filter.k
-                    assert convolved_image.parity == convolved_image_slow.parity == (image.parity + geom_filter.parity) %2
-
-                    # print(image.shape())
-                    # print(geom_filter.shape())
-                    # print(convolved_image.shape())
-                    # print(convolved_image_slow.shape())
-                    print(D,k_img,k_filter)
-                    assert jnp.allclose(convolved_image.data, convolved_image_slow.data)
 
 def testUniqueInvariantFilters():
     # ensure that all the filters are actually invariant
@@ -119,22 +61,7 @@ def testUniqueInvariantFilters():
 
 # testUniqueInvariantFilters()
 
-# testIK0_FK0()
-# testIK0_FK1()
-
-testConvolveWithRandoms()
-
-# key = random.PRNGKey(0)
-
-# #N=10, D=2, parity=0, k=2
-# rand_img = geom.geometric_image(random.uniform(key, shape=(1000,1000,2)), parity=0, D=2)
-
-# #N=3, D=2, parity=0, k=0
-# geom_filter = geom.geometric_filter(jnp.array([[[1,1], [0,0], [1,1]], [[0,0],[0,0],[0,0]], [[1,1],[0,0],[1,1]]]), parity=0, D=2)
-
-# convolved_img = rand_img.convolve_with(geom_filter)
-# # print(convolved_img.data)
-# print(convolved_img.shape())
+testIK0_FK1()
 
 
 

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -25,12 +25,10 @@ import itertools as it
 import numpy as np #removing this
 import jax.numpy as jnp
 import jax.lax
-import jax.scipy as jsp
 import pylab as plt
 import matplotlib.cm as cm
 from matplotlib.colors import ListedColormap
 import cmastro
-import time
 
 TINY = 1.e-5
 

--- a/tests/test_geometric_image.py
+++ b/tests/test_geometric_image.py
@@ -213,57 +213,57 @@ class TestGeometricImage:
                 assert jnp.linalg.norm(pixel) < (1 + TINY)
 
 
-    def testConvSubimage(self):
-        image1 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)
-        filter1 = geometric_filter(jnp.zeros(25).reshape((5,5)), 0, 2)
-        subimage1 = image1.conv_subimage((0,0), filter1)
-        assert subimage1.shape() == (5,5)
-        assert subimage1.D == image1.D
-        assert subimage1.N == filter1.N
-        assert subimage1.k == image1.k
-        assert subimage1.parity == image1.parity
-        assert (subimage1.data == jnp.array(
-            [
-                [18,19,15,16,17],
-                [23,24,20,21,22],
-                [3,4,0,1,2],
-                [8,9,5,6,7],
-                [13,14,10,11,12],
-            ],
-        dtype=int)).all()
+    # def testConvSubimage(self):
+    #     image1 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)
+    #     filter1 = geometric_filter(jnp.zeros(25).reshape((5,5)), 0, 2)
+    #     subimage1 = image1.conv_subimage((0,0), filter1)
+    #     assert subimage1.shape() == (5,5)
+    #     assert subimage1.D == image1.D
+    #     assert subimage1.N == filter1.N
+    #     assert subimage1.k == image1.k
+    #     assert subimage1.parity == image1.parity
+    #     assert (subimage1.data == jnp.array(
+    #         [
+    #             [18,19,15,16,17],
+    #             [23,24,20,21,22],
+    #             [3,4,0,1,2],
+    #             [8,9,5,6,7],
+    #             [13,14,10,11,12],
+    #         ],
+    #     dtype=int)).all()
 
-        subimage2 = image1.conv_subimage((4,4), filter1)
-        assert subimage2.shape() == (5,5)
-        assert subimage2.D == image1.D
-        assert subimage2.N == filter1.N
-        assert subimage2.k == image1.k
-        assert subimage2.parity == image1.parity
-        assert (subimage2.data == jnp.array(
-            [
-                [12,13,14,10,11],
-                [17,18,19,15,16],
-                [22,23,24,20,21],
-                [2,3,4,0,1],
-                [7,8,9,5,6],
-            ],
-        dtype=int)).all()
+    #     subimage2 = image1.conv_subimage((4,4), filter1)
+    #     assert subimage2.shape() == (5,5)
+    #     assert subimage2.D == image1.D
+    #     assert subimage2.N == filter1.N
+    #     assert subimage2.k == image1.k
+    #     assert subimage2.parity == image1.parity
+    #     assert (subimage2.data == jnp.array(
+    #         [
+    #             [12,13,14,10,11],
+    #             [17,18,19,15,16],
+    #             [22,23,24,20,21],
+    #             [2,3,4,0,1],
+    #             [7,8,9,5,6],
+    #         ],
+    #     dtype=int)).all()
 
-        image2 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)*geometric_image(jnp.ones((5,5,2)), 0, 2)
-        subimage3 = image2.conv_subimage((0,0), filter1)
-        assert subimage3.shape() == (5,5,2)
-        assert subimage3.D == image2.D
-        assert subimage3.N == filter1.N
-        assert subimage3.k == image2.k
-        assert subimage3.parity == image2.parity
-        assert (subimage3.data == jnp.array(
-            [
-                [x*jnp.array([1,1]) for x in [18,19,15,16,17]],
-                [x*jnp.array([1,1]) for x in [23,24,20,21,22]],
-                [x*jnp.array([1,1]) for x in [3,4,0,1,2]],
-                [x*jnp.array([1,1]) for x in [8,9,5,6,7]],
-                [x*jnp.array([1,1]) for x in [13,14,10,11,12]],
-            ],
-        dtype=int)).all()
+    #     image2 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)*geometric_image(jnp.ones((5,5,2)), 0, 2)
+    #     subimage3 = image2.conv_subimage((0,0), filter1)
+    #     assert subimage3.shape() == (5,5,2)
+    #     assert subimage3.D == image2.D
+    #     assert subimage3.N == filter1.N
+    #     assert subimage3.k == image2.k
+    #     assert subimage3.parity == image2.parity
+    #     assert (subimage3.data == jnp.array(
+    #         [
+    #             [x*jnp.array([1,1]) for x in [18,19,15,16,17]],
+    #             [x*jnp.array([1,1]) for x in [23,24,20,21,22]],
+    #             [x*jnp.array([1,1]) for x in [3,4,0,1,2]],
+    #             [x*jnp.array([1,1]) for x in [8,9,5,6,7]],
+    #             [x*jnp.array([1,1]) for x in [13,14,10,11,12]],
+    #         ],
+    #     dtype=int)).all()
 
     def testConvolveWithIK0_FK0(self):
         """
@@ -297,7 +297,7 @@ class TestGeometricImage:
             ],
         dtype=int)).all()
 
-    def testConvolveWithIK1_FK1(self):
+    def testConvolveWithIK0_FK1(self):
         """
         Convolve with where the input is k=0, and the filter is k=1
         """

--- a/tests/test_geometric_image.py
+++ b/tests/test_geometric_image.py
@@ -213,57 +213,57 @@ class TestGeometricImage:
                 assert jnp.linalg.norm(pixel) < (1 + TINY)
 
 
-    # def testConvSubimage(self):
-    #     image1 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)
-    #     filter1 = geometric_filter(jnp.zeros(25).reshape((5,5)), 0, 2)
-    #     subimage1 = image1.conv_subimage((0,0), filter1)
-    #     assert subimage1.shape() == (5,5)
-    #     assert subimage1.D == image1.D
-    #     assert subimage1.N == filter1.N
-    #     assert subimage1.k == image1.k
-    #     assert subimage1.parity == image1.parity
-    #     assert (subimage1.data == jnp.array(
-    #         [
-    #             [18,19,15,16,17],
-    #             [23,24,20,21,22],
-    #             [3,4,0,1,2],
-    #             [8,9,5,6,7],
-    #             [13,14,10,11,12],
-    #         ],
-    #     dtype=int)).all()
+    def testConvSubimage(self):
+        image1 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)
+        filter1 = geometric_filter(jnp.zeros(25).reshape((5,5)), 0, 2)
+        subimage1 = image1.conv_subimage((0,0), filter1)
+        assert subimage1.shape() == (5,5)
+        assert subimage1.D == image1.D
+        assert subimage1.N == filter1.N
+        assert subimage1.k == image1.k
+        assert subimage1.parity == image1.parity
+        assert (subimage1.data == jnp.array(
+            [
+                [18,19,15,16,17],
+                [23,24,20,21,22],
+                [3,4,0,1,2],
+                [8,9,5,6,7],
+                [13,14,10,11,12],
+            ],
+        dtype=int)).all()
 
-    #     subimage2 = image1.conv_subimage((4,4), filter1)
-    #     assert subimage2.shape() == (5,5)
-    #     assert subimage2.D == image1.D
-    #     assert subimage2.N == filter1.N
-    #     assert subimage2.k == image1.k
-    #     assert subimage2.parity == image1.parity
-    #     assert (subimage2.data == jnp.array(
-    #         [
-    #             [12,13,14,10,11],
-    #             [17,18,19,15,16],
-    #             [22,23,24,20,21],
-    #             [2,3,4,0,1],
-    #             [7,8,9,5,6],
-    #         ],
-    #     dtype=int)).all()
+        subimage2 = image1.conv_subimage((4,4), filter1)
+        assert subimage2.shape() == (5,5)
+        assert subimage2.D == image1.D
+        assert subimage2.N == filter1.N
+        assert subimage2.k == image1.k
+        assert subimage2.parity == image1.parity
+        assert (subimage2.data == jnp.array(
+            [
+                [12,13,14,10,11],
+                [17,18,19,15,16],
+                [22,23,24,20,21],
+                [2,3,4,0,1],
+                [7,8,9,5,6],
+            ],
+        dtype=int)).all()
 
-    #     image2 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)*geometric_image(jnp.ones((5,5,2)), 0, 2)
-    #     subimage3 = image2.conv_subimage((0,0), filter1)
-    #     assert subimage3.shape() == (5,5,2)
-    #     assert subimage3.D == image2.D
-    #     assert subimage3.N == filter1.N
-    #     assert subimage3.k == image2.k
-    #     assert subimage3.parity == image2.parity
-    #     assert (subimage3.data == jnp.array(
-    #         [
-    #             [x*jnp.array([1,1]) for x in [18,19,15,16,17]],
-    #             [x*jnp.array([1,1]) for x in [23,24,20,21,22]],
-    #             [x*jnp.array([1,1]) for x in [3,4,0,1,2]],
-    #             [x*jnp.array([1,1]) for x in [8,9,5,6,7]],
-    #             [x*jnp.array([1,1]) for x in [13,14,10,11,12]],
-    #         ],
-    #     dtype=int)).all()
+        image2 = geometric_image(jnp.arange(25).reshape((5,5)), 0, 2)*geometric_image(jnp.ones((5,5,2)), 0, 2)
+        subimage3 = image2.conv_subimage((0,0), filter1)
+        assert subimage3.shape() == (5,5,2)
+        assert subimage3.D == image2.D
+        assert subimage3.N == filter1.N
+        assert subimage3.k == image2.k
+        assert subimage3.parity == image2.parity
+        assert (subimage3.data == jnp.array(
+            [
+                [x*jnp.array([1,1]) for x in [18,19,15,16,17]],
+                [x*jnp.array([1,1]) for x in [23,24,20,21,22]],
+                [x*jnp.array([1,1]) for x in [3,4,0,1,2]],
+                [x*jnp.array([1,1]) for x in [8,9,5,6,7]],
+                [x*jnp.array([1,1]) for x in [13,14,10,11,12]],
+            ],
+        dtype=int)).all()
 
     def testConvolveWithIK0_FK0(self):
         """
@@ -318,6 +318,30 @@ class TestGeometricImage:
             [[3,0],[-3,1],[0,-1]],
             [[-1,-2],[-1,-1],[2,-3]]
         ], dtype=int)).all()
+
+    def testConvolveWithRandoms(self):
+        # this test uses convolve_with_slow to test convolve_with, possibly the blind leading the blind
+        key = random.PRNGKey(0)
+        N=3
+
+        for D in [2,3]:
+            for k_img in range(3):
+                key, subkey = random.split(key)
+                image = geometric_image(random.uniform(subkey, shape=((N,)*D + (D,)*k_img)), 0, D)
+
+                for k_filter in range(3):
+                    key, subkey = random.split(key)
+                    geom_filter = geometric_filter(random.uniform(subkey, shape=((3,)*D + (D,)*k_filter)), 0, D)
+
+                    convolved_image = image.convolve_with(geom_filter)
+                    convolved_image_slow = image.convolve_with_slow(geom_filter)
+
+                    assert convolved_image.D == convolved_image_slow.D == image.D
+                    assert convolved_image.N == convolved_image_slow.N == image.N
+                    assert convolved_image.k == convolved_image_slow.k == image.k + geom_filter.k
+                    assert convolved_image.parity == convolved_image_slow.parity == (image.parity + geom_filter.parity) %2
+                    assert jnp.allclose(convolved_image.data, convolved_image_slow.data)
+
 
     # def testConvolveCommutativity(self):
     #     image1 = geometric_image(jnp.array([[2,1,0], [0,0,-3], [2,0,1]], dtype=int), 0, 2)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -150,7 +150,7 @@ class TestMisc:
 
                                 # test that the convolution with the invariant filters is equivariant to gg
                                 # convolutions are currently too slow to test this every time, but should be tested
-                                # assert jnp.allclose(
-                                #     image.convolve_with(geom_filter).times_group_element(gg).data,
-                                #     image.times_group_element(gg).convolve_with(geom_filter).data,
-                                # )
+                                assert jnp.allclose(
+                                    image.convolve_with(geom_filter).times_group_element(gg).data,
+                                    image.times_group_element(gg).convolve_with(geom_filter).data,
+                                )


### PR DESCRIPTION
## Changes
- update `how_many_linear_operations` notebook to work with updated code
- update `hash_list`, so now it is just `hash` and it works with jnp.array
- change `convolve_with` existing implementation to `convolve_with slow`, keeping it around for testing purposes tho
- write the new `convolve_with` function, see comments on that function for an extended description. But basically it expands the image on the torus, performs the outer products on the tensors of the image and the filter so now they have the same shape, then vectorizes those tensors and uses the jax.lax convolve function, essentially treating the tensors as channels. Then we unwrap the vectorized tensors, and bob's your uncle. 

## Testing
- added more unit tests, use the old convolve function to test the new one, which is not exactly kosher, but we will do it for the time being
- use convolutions to test the equivariance of the invariant filters

## Doc Changes
- none