### PR TITLE
add vector example, some tests

### DIFF
--- a/notebooks/find_quadratic_operations.ipynb
+++ b/notebooks/find_quadratic_operations.ipynb
@@ -44,7 +44,6 @@
    "outputs": [],
    "source": [
     "allfilters, maxn = geom.get_invariant_filters([N], range(max_k+1), [0,1], D, group_operators)\n",
-    "allfilters[(D,M,2,0)] = allfilters[(D,M,2,0)]\n",
     "for key in allfilters.keys():\n",
     "    D, M, k, parity = key\n",
     "    names = [\"{} {}\".format(geom.tensor_name(k, parity), i) for i in range(len(allfilters[key]))]\n",
@@ -171,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32551590",
+   "id": "3e3a9e68",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/find_quadratic_operations.ipynb
+++ b/notebooks/find_quadratic_operations.ipynb
@@ -21,7 +21,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "63a56152",
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "D = 2\n",
@@ -36,10 +38,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "019077b6",
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
-    "allfilters, maxn = geom.get_invariant_filters_dict([N], range(max_k+1), [0,1], D, group_operators)\n",
+    "allfilters, maxn = geom.get_invariant_filters([N], range(max_k+1), [0,1], D, group_operators)\n",
+    "allfilters[(D,M,2,0)] = allfilters[(D,M,2,0)]\n",
     "for key in allfilters.keys():\n",
     "    D, M, k, parity = key\n",
     "    names = [\"{} {}\".format(geom.tensor_name(k, parity), i) for i in range(len(allfilters[key]))]\n",
@@ -111,23 +116,16 @@
     "            ((c1.parity + c2.parity + c3.parity + vector_image.parity)%2 == 0)\n",
     "        ):\n",
     "            img = quadratic_filter(vector_image, c1, c2, c3)\n",
+    "            \n",
+    "            for idxs in geom.get_contraction_indices(img.k, vector_image.k):\n",
     "\n",
-    "            tuple_pairs = it.combinations(it.combinations(range(img.k),2),(img.k-vector_image.k) // 2)\n",
-    "            pairs = np.array([np.array(x).reshape((img.k-vector_image.k,)) for x in tuple_pairs])\n",
-    "            unique_rows = np.array([True if len(np.unique(row)) == len(row) else False for row in pairs])\n",
-    "            unique_pairs = pairs[unique_rows]\n",
-    "\n",
-    "            for idxs in unique_pairs:\n",
-    "                #take every two elements and form tuple pairs of them\n",
-    "                tupled_idxs = tuple((x,y) for x,y in zip(idxs[0::2], idxs[1::2]))\n",
-    "                \n",
-    "                img_contracted = img.multicontract(tupled_idxs)\n",
+    "                img_contracted = img.multicontract(idxs)\n",
     "                assert img_contracted.shape() == vector_image.shape()\n",
     "\n",
     "                long_image = img_contracted.data.flatten()\n",
     "                for extra_image in extra_images:\n",
     "                    extra_img = quadratic_filter(extra_image, c1, c2, c3)\n",
-    "                    extra_img_data = extra_img.multicontract(tupled_idxs).data.flatten()\n",
+    "                    extra_img_data = extra_img.multicontract(idxs).data.flatten()\n",
     "                    long_image = jnp.concatenate((long_image, extra_img_data))\n",
     "\n",
     "                vector_images.append(long_image)\n",
@@ -139,7 +137,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2a424a43",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "vector_image, *extra_images = vector_images\n",
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36f4f958",
+   "id": "32551590",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/how_many_linear_operations.ipynb
+++ b/notebooks/how_many_linear_operations.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "allfilters, maxn = geom.get_invariant_filters_dict([3], [0,1,2], [0,1], D, group_operators)\n",
+    "allfilters, maxn = geom.get_invariant_filters([3], [0,1,2], [0,1], D, group_operators)\n",
     "for key in allfilters.keys():\n",
     "    D, M, k, parity = key\n",
     "    names = [\"{} {}\".format(geom.tensor_name(k, parity), i) for i in range(len(allfilters[key]))]\n",

--- a/scripts/vector_example.py
+++ b/scripts/vector_example.py
@@ -1,0 +1,126 @@
+import itertools as it
+import numpy as np
+import jax.numpy as jnp
+from jax import value_and_grad, jit, random, vmap
+import geometricconvolutions.geometric as geom
+
+def conv_layer(params, x, conv_filters):
+    # Given params, an input, a list of convolutional filters
+    assert len(params) == len(conv_filters) #for right now, a single conv layer
+    return [x.convolve_with(conv_filter).times_scalar(param) for param, conv_filter in zip(params, conv_filters)]
+
+@jit
+def quadratic_layer(x, conv_filters):
+    first_layer_out = conv_layer(np.ones(len(conv_filters)), x, conv_filters)
+
+    prods = []
+    for c1_idx, c2_idx in it.combinations(range(len(conv_filters)), 2):
+        c1x = first_layer_out[c1_idx]
+        c2x = first_layer_out[c2_idx]
+        prod = c1x * c2x
+        for conv_filter in conv_filters:
+            if (
+                ((prod.k + conv_filter.k - x.k) % 2 == 0) and
+                ((prod.parity + conv_filter.parity - x.parity) % 2 == 0)
+            ):
+                #compatible filter
+                prods.append(prod.convolve_with(conv_filter))
+
+    return prods
+
+def net(params, x, conv_filters):
+    # A simple neural net with a quadratic convolution layer.
+    prods = quadratic_layer(x, conv_filters)
+
+    prods_by_k = { img.k: [] for img in prods }
+    for img in prods:
+        prods_by_k[img.k].append(img)
+
+    i = 0
+    final_list = []
+    for lst in prods_by_k.values():
+        sum_image_data = jnp.sum(jnp.array([out.data*param for out,param in zip(lst, params[i:i+len(lst)])]), axis=0)
+        img = geom.GeometricImage(sum_image_data, x.parity, x.D)
+
+        if img.k == 0:
+            final_list.append(img)
+        else:
+            for idxs in geom.get_contraction_indices(img.k, x.k):
+                final_list.append(img.multicontract(idxs))
+
+        i += len(lst)
+
+    data = jnp.sum(jnp.array([out.data*param for out,param in zip(final_list, params[i:i+len(final_list)])]), axis=0)
+    return geom.GeometricImage(data, x.parity, x.D)
+
+@jit
+def loss(params, x, y, conv_filters):
+    # Run the neural network, then calculate the MSE loss with the expected output y
+    out = net(params, x, conv_filters)
+
+    # calculate the mean squared error difference between y and out
+    mse = jnp.sqrt(jnp.sum((y.data - out.data) ** 2) / out.data.size)
+    return mse
+
+def batch_loss(params, X, Y, conv_filters):
+    # Loss function for batches, should be a way to vmap this.
+    return jnp.mean(jnp.array([loss(params, x, y, conv_filters) for x,y in zip(X,Y)]))
+
+def get_batch(X, Y, batch_size):
+    batch_indices = np.random.permutation(len(X))[:batch_size]
+    return [X[idx] for idx in batch_indices], [Y[idx] for idx in batch_indices]
+
+def train(X, Y, conv_filters, batch_loss, epochs, params, batch_size=16, initial_lr=0.01, decay=0.01, min_lr=None):
+    # Train the model. Use a simple adaptive learning rate scheme, and go until the learning rate is small.
+    batch_loss_grad = value_and_grad(batch_loss)
+
+    learning_rate = initial_lr
+    for i in range(epochs):
+        X_batch, Y_batch = get_batch(X, Y, batch_size)
+        loss_val, grads = batch_loss_grad(params, X_batch, Y_batch, conv_filters)
+        params = params - learning_rate * grads
+        if ((min_lr is None) or (learning_rate > min_lr)):
+            learning_rate = initial_lr * jnp.exp(-1*decay*i)
+
+        if (i % (epochs // np.min([10,epochs])) == 0):
+            print(loss_val, learning_rate)
+
+    return params, loss_val
+
+#Main
+key = random.PRNGKey(0)
+
+D = 2
+N = 64 #image size
+k = 1
+M = 3  #filter image size
+num_images = 1
+
+group_actions = geom.make_all_operators(D)
+conv_filters = geom.get_invariant_filters(
+    Ms=[M],
+    ks=[0,1,2],
+    parities=[0,1],
+    D=D,
+    operators=group_actions,
+    return_list=True,
+)
+
+# construct num_images scalar images, (N,N)
+key, subkey = random.split(key)
+X = [geom.GeometricImage(data, 0, D) for data in random.normal(subkey, shape=((num_images,) + (N,)*D + (D,)*k))]
+Y = [x.convolve_with(conv_filters[2]).convolve_with(conv_filters[1]) for x in X]
+
+key, subkey = random.split(key)
+params = random.normal(subkey, shape=(196+123,)) #for k=1
+
+params, loss_val = train(X, Y, conv_filters, batch_loss=batch_loss, epochs=10, params=params)
+
+print('train loss:', batch_loss(params, X, Y, conv_filters))
+
+key, subkey = random.split(key)
+X_test = [geom.GeometricImage(data, 0, D) for data in random.normal(subkey, shape=((num_images,) + (N,)*D + (D,)*k))]
+Y_test = [x.convolve_with(conv_filters[2]).convolve_with(conv_filters[1]) for x in X_test]
+
+print('test loss:', batch_loss(params, X_test, Y_test, conv_filters))
+

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -28,7 +28,6 @@ import jax.lax
 from jax import jit
 from jax.tree_util import register_pytree_node_class
 from functools import partial
-import numbers
 
 TINY = 1.e-5
 LETTERS = 'abcdefghijklmnopqrstuvwxyxABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -173,10 +172,9 @@ def get_unique_invariant_filters(M, k, parity, D, operators, scale='normalize'):
     amps[np.abs(amps) < TINY] = 0.
 
     # order them
+    filters = [GeometricFilter(aa.reshape(shape), parity, D) for aa in amps]
     if (scale == 'normalize'):
-        filters = [GeometricFilter(aa.reshape(shape), parity, D).normalize() for aa in amps]
-    elif (scale == 'one'):
-        filters = [GeometricFilter(aa.reshape(shape), parity, D) for aa in amps]
+        filters = [ff.normalize() for ff in filters]
 
     norms = [ff.bigness() for ff in filters]
     I = np.argsort(norms)

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -28,6 +28,7 @@ import jax.lax
 from jax import jit
 from jax.tree_util import register_pytree_node_class
 from functools import partial
+import numbers
 
 TINY = 1.e-5
 LETTERS = 'abcdefghijklmnopqrstuvwxyxABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -117,7 +118,7 @@ class LeviCivitaSymbol:
 # ------------------------------------------------------------------------------
 # PART 4: Use group averaging to find unique invariant filters.
 
-def get_unique_invariant_filters(M, k, parity, D, operators):
+def get_unique_invariant_filters(M, k, parity, D, operators, scale='normalize'):
     """
     Use group averaging to generate all the unique invariant filters
     args:
@@ -126,7 +127,10 @@ def get_unique_invariant_filters(M, k, parity, D, operators):
         parity (int):  0 or 1, 0 is for normal tensors, 1 for pseudo-tensors
         D (int): image dimension
         operators (jnp-array): array of operators of a group
+        scale (string): option for scaling the values of the filters, 'normalize' (default) to make amplitudes of each
+        tensor +/- 1. 'one' to set them all to 1.
     """
+    assert scale == 'normalize' or scale == 'one'
 
     # make the seed filters
     tmp = GeometricFilter.zeros(M, k, parity, D)
@@ -169,7 +173,11 @@ def get_unique_invariant_filters(M, k, parity, D, operators):
     amps[np.abs(amps) < TINY] = 0.
 
     # order them
-    filters = [GeometricFilter(aa.reshape(shape), parity, D).normalize() for aa in amps]
+    if (scale == 'normalize'):
+        filters = [GeometricFilter(aa.reshape(shape), parity, D).normalize() for aa in amps]
+    elif (scale == 'one'):
+        filters = [GeometricFilter(aa.reshape(shape), parity, D) for aa in amps]
+
     norms = [ff.bigness() for ff in filters]
     I = np.argsort(norms)
     filters = [filters[i] for i in I]
@@ -179,19 +187,26 @@ def get_unique_invariant_filters(M, k, parity, D, operators):
 
     return filters
 
-def get_invariant_filters_dict(Ms, ks, parities, D, operators):
+def get_invariant_filters(Ms, ks, parities, D, operators, scale='normalize', return_list=False):
     """
-    Use group averaging to generate all the unique invariant filters for the ranges of Ms, ks, and parities
+    Use group averaging to generate all the unique invariant filters for the ranges of Ms, ks, and parities. By default
+    it returns the filters in a dictionary with the key (D,M,k,parity), but flattens to a list if return_list=True
     args:
         Ms (iterable of int): filter side lengths
         ks (iterable of int): tensor orders
         parities (iterable of int):  0 or 1, 0 is for normal tensors, 1 for pseudo-tensors
         D (int): image dimension
         operators (jnp-array): array of operators of a group
+        scale (string): option for scaling the values of the filters, 'normalize' (default) to make amplitudes of each
+        tensor +/- 1. 'one' to set them all to 1.
+        return_list (bool): defaults to False, if true return allfilters as a list
     returns:
-        allfilters: a dictionary of filters of the specified D, M, k, and parity
-        maxn: a dictionary that tracks the longest number of filters per key, for a particular D,M combo
+        allfilters: a dictionary of filters of the specified D, M, k, and parity. If return_list=True, this is a list
+        maxn: a dictionary that tracks the longest number of filters per key, for a particular D,M combo. Not returned
+            if return_list=True
     """
+    assert scale == 'normalize' or scale == 'one'
+
     allfilters = {}
     names = {}
     maxn = {}
@@ -200,15 +215,37 @@ def get_invariant_filters_dict(Ms, ks, parities, D, operators):
         for k in ks: #tensor order
             for parity in parities: #parity
                 key = (D, M, k, parity)
-                allfilters[key] = get_unique_invariant_filters(M, k, parity, D, operators)
+                allfilters[key] = get_unique_invariant_filters(M, k, parity, D, operators, scale)
                 n = len(allfilters[key])
                 if n > maxn[(D, M)]:
                     maxn[(D, M)] = n
 
-    return allfilters, maxn
+    if return_list:
+        return list(it.chain(*list(allfilters.values())))
+    else:
+        return allfilters, maxn
 
 # ------------------------------------------------------------------------------
 # PART 5: Define geometric (k-tensor, torus) images.
+
+def get_contraction_indices(initial_k, final_k):
+    """
+    Get all possible unique indices for multicontraction. Returns a list of indices. The indices are a tuple of tuples
+    where each of the inner tuples are pairs of indices. For example, if initial_k=5, final_k = 4, one element of the
+    list that is returned will be ((0,1), (2,3)), another will be ((1,4), (0,2)), etc.
+
+    Note that contracting (0,1) is the same as contracting (1,0). Also, contracting ((0,1),(2,3)) is the same as
+    contracting ((2,3),(0,1)). In both of those cases, they won't be returned. There are additional contractions that
+    are the same depending on how the image was created, but we don't worry about that complexity here.
+    args:
+        initial_k (int): the starting number of indices that we have
+        final_k (int): the final number of indices that we want to end up with
+    """
+    tuple_pairs = it.combinations(it.combinations(range(initial_k),2),(initial_k - final_k) // 2)
+    pairs = np.array([np.array(pair).reshape((initial_k - final_k,)) for pair in tuple_pairs])
+    unique_rows = np.array([True if len(np.unique(row)) == len(row) else False for row in pairs])
+    unique_pairs = pairs[unique_rows]
+    return [tuple((x,y) for x,y in zip(idxs[0::2], idxs[1::2])) for idxs in unique_pairs]
 
 @partial(jit, static_argnums=1)
 def multicontract(data, indices):
@@ -358,16 +395,40 @@ class GeometricImage:
         assert self.parity == other.parity
         return self.__class__(self.data + other.data, self.parity, self.D)
 
-    def __mul__(self, other):
+    def __sub__(self, other):
         """
-        Return the tensor product of each pixel as a new GeometricImage
+        Subtraction operator for GeometricImages. Both must be the same size and parity. Returns a new GeometricImage.
+        args:
+            other (GeometricImage): other image to add the the first one
         """
         assert self.D == other.D
         assert self.N == other.N
+        assert self.k == other.k
+        assert self.parity == other.parity
+        return self.__class__(self.data - other.data, self.parity, self.D)
 
-        image_a_data, image_b_data = GeometricImage.pre_tensor_product_expand(self, other)
-        #now that the shapes match, we can do elementwise multiplication
-        return self.__class__(image_a_data * image_b_data, self.parity + other.parity, self.D)
+    def __mul__(self, other):
+        """
+        If other is a scalar, do scalar multiplication of the data. If it is another GeometricImage, do the tensor
+        product at each pixel. Return the result as a new GeometricImage.
+        args:
+            other (GeometricImage or number): scalar or image to multiply by
+        """
+        if (isinstance(other, GeometricImage)):
+            assert self.D == other.D
+            assert self.N == other.N
+            image_a_data, image_b_data = GeometricImage.pre_tensor_product_expand(self, other)
+            #now that the shapes match, we can do elementwise multiplication
+            return self.__class__(image_a_data * image_b_data, self.parity + other.parity, self.D)
+        else: #its an integer or a float, or something that can we can multiply a Jax array by (like a DeviceArray)
+            return self.__class__(self.data * other, self.parity, self.D)
+
+    def __rmul__(self, other):
+        """
+        If other is a scalar, multiply the data by the scalar. This is necessary for doing scalar * image, and it
+        should only be called in that case.
+        """
+        return self * other
 
     def transpose(self, axes_permutation):
         """
@@ -525,11 +586,11 @@ class GeometricImage:
 
     def times_scalar(self, scalar):
         """
-        Scale the data by a scalar, returning a new GeometricImage object
+        Scale the data by a scalar, returning a new GeometricImage object. Alias of the multiplication operator.
         args:
             scalar (number): number to scale everything by
         """
-        return self.__class__(self.data * scalar, self.parity, self.D)
+        return self * scalar
 
     def norm(self):
         """

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -93,3 +93,16 @@ class TestPropositions:
         assert B1.N == B2.N
         assert B1.parity == B2.parity
         assert jnp.allclose(B1.transpose([2,3,4,0,1]).data, B2.data, rtol=geom.TINY, atol=geom.TINY)
+
+    def testOuterProductFilterInvariance(self):
+        # Test that the outer product of two invariant filters is also invariant
+        D = 2
+        group_operators = geom.make_all_operators(D)
+        all_filters = geom.get_invariant_filters([3], [0,1,2], [0,1], D, group_operators, return_list=True)
+        for g in group_operators:
+            for c1 in all_filters:
+                for c2 in all_filters:
+                    assert jnp.allclose(
+                        (c1 * c2).times_group_element(g).data,
+                        (c1 * c2).data,
+                    )


### PR DESCRIPTION
## Changes
- Add vector image example, currently its pretty slow so I haven't tested it all the way down to learning the filters exactly
- add subtraction operator
- make it so that the multiplication operator handles scalars correctly, both for mul and rmul. times_scalar is now deprecated
- add helper function to generate all the possible multicontraction indices
- improve get invariant filters
- add some pytests

## Testing
- run notebooks
- run drummond example, vector_image example
- pytests

## Doc Changes
- None