### PR TITLE
add BatchGeometricImage

### DIFF
--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -20,6 +20,7 @@ def conv_layer(x, conv_filters):
         x (GeometricImage): image that we are applying the filters to
         conv_filters (list of GeometricFilter): the conv_filters we are applying to the image
     """
+    print('compiling conv_layer')
     return [x.convolve_with(conv_filter) for conv_filter in conv_filters]
 
 def make_p_k_dict(images, filters=False, rollup_set={}):

--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -20,7 +20,6 @@ def conv_layer(x, conv_filters):
         x (GeometricImage): image that we are applying the filters to
         conv_filters (list of GeometricFilter): the conv_filters we are applying to the image
     """
-    print('compiling conv_layer')
     return [x.convolve_with(conv_filter) for conv_filter in conv_filters]
 
 def make_p_k_dict(images, filters=False, rollup_set={}):

--- a/tests/test_geometric_image.py
+++ b/tests/test_geometric_image.py
@@ -423,59 +423,6 @@ class TestGeometricImage:
             for pixel in row:
                 assert jnp.linalg.norm(pixel) < (1 + TINY)
 
-
-    def testConvSubimage(self):
-        image1 = GeometricImage(jnp.arange(25).reshape((5,5)), 0, 2)
-        filter1 = GeometricFilter(jnp.zeros(25).reshape((5,5)), 0, 2)
-        subimage1 = image1.conv_subimage((0,0), filter1)
-        assert subimage1.shape() == (5,5)
-        assert subimage1.D == image1.D
-        assert subimage1.N == filter1.N
-        assert subimage1.k == image1.k
-        assert subimage1.parity == image1.parity
-        assert (subimage1.data == jnp.array(
-            [
-                [18,19,15,16,17],
-                [23,24,20,21,22],
-                [3,4,0,1,2],
-                [8,9,5,6,7],
-                [13,14,10,11,12],
-            ],
-        dtype=int)).all()
-
-        subimage2 = image1.conv_subimage((4,4), filter1)
-        assert subimage2.shape() == (5,5)
-        assert subimage2.D == image1.D
-        assert subimage2.N == filter1.N
-        assert subimage2.k == image1.k
-        assert subimage2.parity == image1.parity
-        assert (subimage2.data == jnp.array(
-            [
-                [12,13,14,10,11],
-                [17,18,19,15,16],
-                [22,23,24,20,21],
-                [2,3,4,0,1],
-                [7,8,9,5,6],
-            ],
-        dtype=int)).all()
-
-        image2 = GeometricImage(jnp.arange(25).reshape((5,5)), 0, 2)*GeometricImage(jnp.ones((5,5,2)), 0, 2)
-        subimage3 = image2.conv_subimage((0,0), filter1)
-        assert subimage3.shape() == (5,5,2)
-        assert subimage3.D == image2.D
-        assert subimage3.N == filter1.N
-        assert subimage3.k == image2.k
-        assert subimage3.parity == image2.parity
-        assert (subimage3.data == jnp.array(
-            [
-                [x*jnp.array([1,1]) for x in [18,19,15,16,17]],
-                [x*jnp.array([1,1]) for x in [23,24,20,21,22]],
-                [x*jnp.array([1,1]) for x in [3,4,0,1,2]],
-                [x*jnp.array([1,1]) for x in [8,9,5,6,7]],
-                [x*jnp.array([1,1]) for x in [13,14,10,11,12]],
-            ],
-        dtype=int)).all()
-
     def testConvolveWithIK0_FK0(self):
         """
         Convolve with where the input is k=0, and the filter is k=0

--- a/tests/test_slow.py
+++ b/tests/test_slow.py
@@ -10,9 +10,95 @@ from jax import random
 
 TINY = 1.e-5
 
+def conv_subimage(image, center_key, filter_image, filter_image_keys=None):
+    """
+    Get the subimage (on the torus) centered on center_idx that will be convolved with filter_image
+    args:
+        center_key (index tuple): tuple index of the center of this convolution
+        filter_image (GeometricFilter): the GeometricFilter we are convolving with
+        filter_image_keys (list): For efficiency, the key offsets of the filter_image. Defaults to None.
+    """
+    if filter_image_keys is None:
+        filter_image_keys = filter_image.key_array(centered=True) #centered key array
+
+    key_list = image.hash(filter_image_keys + jnp.array(center_key)) #key list on the torus
+    #values, reshaped to the correct shape, which is the filter_image shape, while still having the tensor shape
+    vals = image[key_list].reshape(filter_image.image_shape() + image.pixel_shape())
+    return image.__class__(vals, image.parity, image.D)
+
+def convolve_with_slow(image, filter_image):
+    """
+    Apply the convolution filter_image to this geometric image. Keeping this around for testing.
+    args:
+        filter_image (GeometricFilter-like): convolution that we are applying, can be an image or a filter
+    """
+    newimage = image.__class__.zeros(image.N, image.k + filter_image.k,
+                                     image.parity + filter_image.parity, image.D)
+
+    if (isinstance(filter_image, GeometricImage)):
+        filter_image = GeometricFilter.from_image(filter_image) #will break if N is not odd
+
+    filter_image_keys = filter_image.key_array(centered=True)
+    for key in image.keys():
+        subimage = conv_subimage(image, key, filter_image, filter_image_keys)
+        newimage[key] = jnp.sum((subimage * filter_image).data, axis=tuple(range(image.D)))
+    return newimage
+
 class TestSlowTests:
 
     # Test reserved for the slow tests, we only want to test these when we run the full battery
+
+    def testConvSubimage(self):
+        image1 = GeometricImage(jnp.arange(25).reshape((5,5)), 0, 2)
+        filter1 = GeometricFilter(jnp.zeros(25).reshape((5,5)), 0, 2)
+        subimage1 = conv_subimage(image1, (0,0), filter1)
+        assert subimage1.shape() == (5,5)
+        assert subimage1.D == image1.D
+        assert subimage1.N == filter1.N
+        assert subimage1.k == image1.k
+        assert subimage1.parity == image1.parity
+        assert (subimage1.data == jnp.array(
+            [
+                [18,19,15,16,17],
+                [23,24,20,21,22],
+                [3,4,0,1,2],
+                [8,9,5,6,7],
+                [13,14,10,11,12],
+            ],
+        dtype=int)).all()
+
+        subimage2 = conv_subimage(image1, (4,4), filter1)
+        assert subimage2.shape() == (5,5)
+        assert subimage2.D == image1.D
+        assert subimage2.N == filter1.N
+        assert subimage2.k == image1.k
+        assert subimage2.parity == image1.parity
+        assert (subimage2.data == jnp.array(
+            [
+                [12,13,14,10,11],
+                [17,18,19,15,16],
+                [22,23,24,20,21],
+                [2,3,4,0,1],
+                [7,8,9,5,6],
+            ],
+        dtype=int)).all()
+
+        image2 = GeometricImage(jnp.arange(25).reshape((5,5)), 0, 2)*GeometricImage(jnp.ones((5,5,2)), 0, 2)
+        subimage3 = conv_subimage(image2, (0,0), filter1)
+        assert subimage3.shape() == (5,5,2)
+        assert subimage3.D == image2.D
+        assert subimage3.N == filter1.N
+        assert subimage3.k == image2.k
+        assert subimage3.parity == image2.parity
+        assert (subimage3.data == jnp.array(
+            [
+                [x*jnp.array([1,1]) for x in [18,19,15,16,17]],
+                [x*jnp.array([1,1]) for x in [23,24,20,21,22]],
+                [x*jnp.array([1,1]) for x in [3,4,0,1,2]],
+                [x*jnp.array([1,1]) for x in [8,9,5,6,7]],
+                [x*jnp.array([1,1]) for x in [13,14,10,11,12]],
+            ],
+        dtype=int)).all()
 
     def testConvolveWithRandoms(self):
         # this test uses convolve_with_slow to test convolve_with, possibly the blind leading the blind
@@ -29,7 +115,7 @@ class TestSlowTests:
                     geom_filter = GeometricFilter(random.uniform(subkey, shape=((3,)*D + (D,)*k_filter)), 0, D)
 
                     convolved_image = image.convolve_with(geom_filter)
-                    convolved_image_slow = image.convolve_with_slow(geom_filter)
+                    convolved_image_slow = convolve_with_slow(image, geom_filter)
 
                     assert convolved_image.D == convolved_image_slow.D == image.D
                     assert convolved_image.N == convolved_image_slow.N == image.N


### PR DESCRIPTION
## Changes
- move `conv_subimage` and `convolve_with_slow` to tests_slow because that is the only place they are used
- add the `BatchGeometricImage` class which inherits from the `GeometricImage` class. It is basically the same, except that it has a parameter L for the size of the batch, and the data shape is (L,N,N,D) for example if the batch size is L, D=2, and k=1
- adjust some of the code in `GeometricImage` to make it easier for `BatchGeometricImage` to inherit its functions. The biggest change is using img.image_shape() to represent everything that isn't the tensor shape, so for `BatchGeometricImage` it includes the L at the beginning.

## Testing
- Some testing, I will make a followup with a dedicated test class for BatchGeometricImage. This is somewhat of a work in progress because I want to test it on the server.

## Doc Changes