### PR TITLE
update find_quadratic_functions to note the similarity of the k0 and k2 filters

### DIFF
--- a/notebooks/find_quadratic_operations.ipynb
+++ b/notebooks/find_quadratic_operations.ipynb
@@ -57,6 +57,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#Under contractions, the 3 scalar filters are the same as the first 3 k=2 filters. Thus we ignore them.\n",
+    "trimmed_filters = allfilters\n",
+    "trimmed_filters[(D,N,0,0)] = []\n",
+    "trimmed_filters[(D,N,0,1)] = []\n",
+    "\n",
     "filter_list = list(it.chain(*list(allfilters.values())))\n",
     "print(len(filter_list))"
    ]
@@ -76,11 +81,9 @@
     "elif (N == 5):\n",
     "    num_images = 7\n",
     "    \n",
-    "for _ in range(num_images):\n",
-    "    key, subkey = random.split(key)\n",
-    "    vector_images.append(\n",
-    "        geom.GeometricImage(random.normal(subkey, shape=((N,)*D + (D,)*img_k)), 0, D).normalize()\n",
-    "    )"
+    "key, subkey = random.split(key)\n",
+    "img_shape = ((num_images,) + (N,)*D + (D,)*img_k)\n",
+    "geom_img = geom.BatchGeometricImage(random.normal(subkey, shape=img_shape), 0, D)"
    ]
   },
   {
@@ -101,10 +104,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def getVectorImgs(vector_image, extra_images = []):\n",
+    "def getVectorImgs(vector_image):\n",
     "    vector_images = []\n",
+    "    names = []\n",
     "    for c1_idx, c2_idx, c3_idx in it.combinations(range(len(filter_list)), 3):\n",
-    "        print(c1_idx, c2_idx, c3_idx)\n",
+    "#     for c1_idx, c2_idx, c3_idx in it.combinations_with_replacement(range(len(filter_list)), 3):\n",
     "        c1 = filter_list[c1_idx]\n",
     "        c2 = filter_list[c2_idx]\n",
     "        c3 = filter_list[c3_idx]\n",
@@ -114,6 +118,7 @@
     "            ((c1.k + c2.k + c3.k + vector_image.k)%2 == 0) and \n",
     "            ((c1.parity + c2.parity + c3.parity + vector_image.parity)%2 == 0)\n",
     "        ):\n",
+    "            print(c1_idx, c2_idx, c3_idx)\n",
     "            img = quadratic_filter(vector_image, c1, c2, c3)\n",
     "\n",
     "            for idxs in geom.get_contraction_indices(img.k, vector_image.k):\n",
@@ -121,15 +126,10 @@
     "                img_contracted = img.multicontract(idxs)\n",
     "                assert img_contracted.shape() == vector_image.shape()\n",
     "\n",
-    "                long_image = img_contracted.data.flatten()\n",
-    "                for extra_image in extra_images:\n",
-    "                    extra_img = quadratic_filter(extra_image, c1, c2, c3)\n",
-    "                    extra_img_data = extra_img.multicontract(idxs).data.flatten()\n",
-    "                    long_image = jnp.concatenate((long_image, extra_img_data))\n",
-    "\n",
-    "                vector_images.append(long_image)\n",
+    "                vector_images.append(img_contracted.data.flatten())\n",
+    "                names.append(((c1_idx, c2_idx, c3_idx), idxs))\n",
     "                \n",
-    "    return jnp.array(vector_images)"
+    "    return jnp.array(vector_images), names"
    ]
   },
   {
@@ -141,19 +141,18 @@
    },
    "outputs": [],
    "source": [
-    "vector_image, *extra_images = vector_images\n",
-    "datablock = getVectorImgs(vector_image, extra_images)"
+    "datablock, names = getVectorImgs(geom_img)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "171ca415",
+   "id": "375f361e",
    "metadata": {},
    "outputs": [],
    "source": [
     "print(datablock.shape)\n",
-    "print(jnp.unique(jnp.around(datablock, decimals=4), axis=0).shape)"
+    "print(jnp.unique(datablock, axis=0).shape)"
    ]
   },
   {
@@ -164,13 +163,13 @@
    "outputs": [],
    "source": [
     "u, s, v = jnp.linalg.svd(jnp.unique(datablock, axis=0))\n",
-    "print(\"there are\", np.sum(s > 10*geom.TINY), \"different images\")"
+    "print(\"there are\", np.sum(s > 100*geom.TINY), \"different images\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e3a9e68",
+   "id": "02b499b4",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -89,6 +89,10 @@ class KroneckerDeltaSymbol:
 
         return cls.symbol_dict[(D,k)]
 
+    @classmethod
+    def get_image(cls, N, D, k):
+        return GeometricImage(jnp.stack([cls.get(D,k) for _ in range(N**D)]).reshape(((N,)*D + (D,)*k)), 0, D)
+
 def permutation_parity(pi):
     """
     Code taken from Sympy Permutations: https://github.com/sympy/sympy/blob/26f7bdbe3f860e7b4492e102edec2d6b429b5aaf/sympy/combinatorics/permutations.py#L114


### PR DESCRIPTION
## Changes
- swap find_quadratic_operations to use the BatchGeometricImage
- note that under contractions, the 3 scalar filters times the KroneckerDeltaSymbol image is the same as the first 3 k2 filters. Thus we can ignore the first 3 scalar filters
- add some test_props for the above property

## Testing
- ran the find_quadratic_operations for N=3,5
- new tests