### PR TITLE
add equality operator, some unit tests

### DIFF
--- a/notebooks/find_quadratic_operations.ipynb
+++ b/notebooks/find_quadratic_operations.ipynb
@@ -43,7 +43,15 @@
    },
    "outputs": [],
    "source": [
-    "allfilters, maxn = geom.get_invariant_filters([N], range(max_k+1), [0,1], D, group_operators, scale='one')\n",
+    "allfilters, maxn = geom.get_invariant_filters(\n",
+    "    [N], \n",
+    "    range(max_k+1), \n",
+    "    [0,1], \n",
+    "    D, \n",
+    "    group_operators, \n",
+    "    scale='one', \n",
+    "    return_maxn=True,\n",
+    ")\n",
     "for key in allfilters.keys():\n",
     "    D, M, k, parity = key\n",
     "    names = [\"{} {}\".format(geom.tensor_name(k, parity), i) for i in range(len(allfilters[key]))]\n",
@@ -108,7 +116,6 @@
     "    vector_images = []\n",
     "    names = []\n",
     "    for c1_idx, c2_idx, c3_idx in it.combinations(range(len(filter_list)), 3):\n",
-    "#     for c1_idx, c2_idx, c3_idx in it.combinations_with_replacement(range(len(filter_list)), 3):\n",
     "        c1 = filter_list[c1_idx]\n",
     "        c2 = filter_list[c2_idx]\n",
     "        c3 = filter_list[c3_idx]\n",
@@ -127,27 +134,24 @@
     "                assert img_contracted.shape() == vector_image.shape()\n",
     "\n",
     "                vector_images.append(img_contracted.data.flatten())\n",
-    "                names.append(((c1_idx, c2_idx, c3_idx), idxs))\n",
     "                \n",
-    "    return jnp.array(vector_images), names"
+    "    return jnp.array(vector_images)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "2a424a43",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "datablock, names = getVectorImgs(geom_img)"
+    "datablock = getVectorImgs(geom_img)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "375f361e",
+   "id": "def03cec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02b499b4",
+   "id": "acca8829",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/how_many_linear_operations.ipynb
+++ b/notebooks/how_many_linear_operations.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "allfilters, maxn = geom.get_invariant_filters([3], [0,1,2], [0,1], D, group_operators)\n",
+    "allfilters, maxn = geom.get_invariant_filters([3], [0,1,2], [0,1], D, group_operators, return_maxn=True)\n",
     "for key in allfilters.keys():\n",
     "    D, M, k, parity = key\n",
     "    names = [\"{} {}\".format(geom.tensor_name(k, parity), i) for i in range(len(allfilters[key]))]\n",

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -224,7 +224,7 @@ def get_invariant_filters(Ms, ks, parities, D, operators, scale='normalize', ret
         scale (string): option for scaling the values of the filters, 'normalize' (default) to make amplitudes of each
         tensor +/- 1. 'one' to set them all to 1.
         return_list (bool): defaults to False, if true return allfilters as a list
-        return_maxn (bool): defaults ot False,, if true returns the length of the max list for each D, M
+        return_maxn (bool): defaults to False, if true returns the length of the max list for each D, M
     returns:
         allfilters: a dictionary of filters of the specified D, M, k, and parity. If return_list=True, this is a list
         maxn: a dictionary that tracks the longest number of filters per key, for a particular D,M combo. Not returned

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -211,7 +211,7 @@ def get_unique_invariant_filters(M, k, parity, D, operators, scale='normalize'):
 
     return filters
 
-def get_invariant_filters(Ms, ks, parities, D, operators, scale='normalize', return_list=False):
+def get_invariant_filters(Ms, ks, parities, D, operators, scale='normalize', return_list=False, return_maxn=False):
     """
     Use group averaging to generate all the unique invariant filters for the ranges of Ms, ks, and parities. By default
     it returns the filters in a dictionary with the key (D,M,k,parity), but flattens to a list if return_list=True
@@ -224,6 +224,7 @@ def get_invariant_filters(Ms, ks, parities, D, operators, scale='normalize', ret
         scale (string): option for scaling the values of the filters, 'normalize' (default) to make amplitudes of each
         tensor +/- 1. 'one' to set them all to 1.
         return_list (bool): defaults to False, if true return allfilters as a list
+        return_maxn (bool): defaults ot False,, if true returns the length of the max list for each D, M
     returns:
         allfilters: a dictionary of filters of the specified D, M, k, and parity. If return_list=True, this is a list
         maxn: a dictionary that tracks the longest number of filters per key, for a particular D,M combo. Not returned
@@ -245,9 +246,13 @@ def get_invariant_filters(Ms, ks, parities, D, operators, scale='normalize', ret
                     maxn[(D, M)] = n
 
     if return_list:
-        return list(it.chain(*list(allfilters.values())))
-    else:
+        allfilters = list(it.chain(*list(allfilters.values())))
+
+    if return_maxn:
         return allfilters, maxn
+    else:
+        return allfilters
+
 
 # ------------------------------------------------------------------------------
 # PART 5: Define geometric (k-tensor, torus) images.
@@ -436,6 +441,19 @@ class GeometricImage:
             yield (key, self[key])
 
     # Binary Operators, Complicated functions
+
+    def __eq__(self, other):
+        """
+        Equality operator, must have same shape, parity, and data within the TINY=1e-5 tolerance.
+        """
+        return (
+            self.D == other.D and
+            self.N == other.N and
+            self.k == other.k and
+            self.parity == other.parity and
+            self.data.shape == other.data.shape and
+            jnp.allclose(self.data, other.data, rtol=TINY, atol=TINY)
+        )
 
     def __add__(self, other):
         """
@@ -911,6 +929,12 @@ class BatchGeometricImage(GeometricImage):
             self.__class__, self.L, self.D, self.N, self.k, self.parity)
 
     # Binary Operators, Complicated functions
+
+    def __eq__(self, other):
+        """
+        Equality operator, must have same L, shape, parity, and data within the TINY=1e-5 tolerance.
+        """
+        return self.L == other.L and super(BatchGeometricImage, self).__eq__(other)
 
     def __mul__(self, other):
         """

--- a/tests/test_batch_geometric_image.py
+++ b/tests/test_batch_geometric_image.py
@@ -27,6 +27,17 @@ class TestBatchGeometricImage:
         with pytest.raises(AssertionError):
             geom.BatchGeometricImage(random.uniform(key, shape=(10,10,2)), 0, 3)
 
+    def testEqual(self):
+        img1 = geom.BatchGeometricImage(jnp.ones((5,10,10,2)), 0, 2)
+
+        # same
+        img2 = geom.BatchGeometricImage(jnp.ones((5,10,10,2)), 0, 2)
+        assert img1 == img2
+
+        # different L
+        img3 = geom.BatchGeometricImage(jnp.ones((7,10,10,2)), 0, 2)
+        assert img1 != img3
+
     def testAdd(self):
         image1 = geom.BatchGeometricImage(jnp.ones((5,10,10,2), dtype=int), 0, 2)
         image2 = geom.BatchGeometricImage(5*jnp.ones((5,10,10,2), dtype=int), 0, 2)

--- a/tests/test_geometric_image.py
+++ b/tests/test_geometric_image.py
@@ -90,7 +90,40 @@ class TestGeometricImage:
         assert image1.D == image2.D
         assert image1.k == image2.k
         assert image1.N == image2.N
-        assert image1 != image2
+        assert image1 == image2
+
+    def testEqual(self):
+        img1 = geom.GeometricImage(jnp.ones((10,10,2)), 0, 2)
+        assert img1 == img1.copy()
+
+        # same
+        img2 = geom.GeometricImage(jnp.ones((10,10,2)), 0, 2)
+        assert img1 == img2
+
+        # different N
+        img3 = geom.GeometricImage(jnp.ones((5,5,2)), 0, 2)
+        assert img1 != img3
+
+        # different k
+        img4 = geom.GeometricImage(jnp.ones((10,10,2,2)), 0, 2)
+        assert img1 != img4
+
+        # different D
+        img5 = geom.GeometricImage(jnp.ones((10,10,10)), 0, 3)
+        assert img1 != img5
+        img6 = geom.GeometricImage(jnp.ones((2,2,2)), 0, 3) #D=3, k=0
+        img7 = geom.GeometricImage(jnp.ones((2,2,2)), 0, 2) #D=2, k=1
+        assert img6 != img7
+
+        # different parity
+        img8 = geom.GeometricImage(jnp.ones((10,10,2)), 1, 2)
+        assert img1 != img8
+
+        #different data
+        img9 = geom.GeometricImage(2*jnp.ones((10,10,2)), 0, 2)
+        assert img1 != img9
+        assert img1 != 1.0001*img1 #outside the error tolerance
+        assert img1 == 1.0000001*img1  #within the error tolerance
 
     def testAdd(self):
         image1 = geom.GeometricImage(jnp.ones((10,10,2), dtype=int), 0, 2)
@@ -559,7 +592,7 @@ class TestGeometricImage:
                 expanded_image = image.anticontract(additional_k)
 
                 for idxs in geom.get_contraction_indices(expanded_image.k, image.k):
-                    assert jnp.allclose(expanded_image.multicontract(idxs).data, image.data)
+                    assert expanded_image.multicontract(idxs) == image
 
     def testPixelSize(self):
         img1 = geom.GeometricImage.zeros(10,0,0,2)


### PR DESCRIPTION
## Changes
- swap get_invariant_filters slightly to return maxn only when asked for
- add an equality operator that checks that all the shape stuff and parity is the same, and data is within TINY tolerance

## Testing
- add unit tests for equality operator
- add unit test for prop that contraction and convolution order can be interchanged, as long as the contraction is on the original image axis indices
- add unit test for the prop that for invariant filters of order k, there is an invariant filter of order k+2 where contracting on any two indices results in the invariant filter of order k
- test notebooks where get_invariant_filters is used, as well as scripts.

## Doc Changes
- none