### PR TITLE
add bias images, activation functions

### DIFF
--- a/scripts/gif_example.py
+++ b/scripts/gif_example.py
@@ -21,7 +21,7 @@ def net(params, x, conv_filters, return_params=False):
     poly_layer = ml.leaky_relu_layer(poly_layer)
 
     final_layer, param_idx = ml.conv_layer(params, int(param_idx), conv_filters, poly_layer, x)
-    contract_layer, param_idx = ml.cascading_contractions(params, int(param_idx), x, final_layer, bias=False)
+    contract_layer, param_idx = ml.cascading_contractions(params, int(param_idx), x, final_layer)
     contract_layer = ml.leaky_relu_layer(contract_layer)
 
     net_output = geom.linear_combination(contract_layer, params[param_idx:(param_idx + len(contract_layer))])

--- a/scripts/gif_example.py
+++ b/scripts/gif_example.py
@@ -15,22 +15,31 @@ def read_gif(infile):
     return iio.imread(infile).astype('float32')[...,0] #only need 1 channel b/c its b/w
 
 def net(params, x, conv_filters, return_params=False):
-    first_layer_out, param_idx = ml.conv_layer(params, 0, conv_filters, [x])
-    second_layer_out, param_idx = ml.conv_layer(params, int(param_idx), conv_filters, first_layer_out)
-    quad_layer_out, param_idx = ml.quad_fast(params, param_idx, second_layer_out)
-    final_layer_out, param_idx = ml.conv_layer(params, int(param_idx), conv_filters, quad_layer_out, x)
-    contracted_images, param_idx = ml.cascading_contractions(params, int(param_idx), x, final_layer_out)
+    first_layer, param_idx = ml.conv_layer(params, 0, conv_filters, [x])
+    second_layer, param_idx = ml.conv_layer(params, int(param_idx), conv_filters, first_layer)
+    poly_layer, param_idx = ml.polynomial_layer(params, int(param_idx), second_layer, poly_degree=2, bias=False)
+    poly_layer = ml.leaky_relu_layer(poly_layer)
 
-    net_output = geom.linear_combination(contracted_images, params[param_idx:(param_idx + len(contracted_images))])
-    return (net_output, param_idx + len(contracted_images)) if return_params else net_output
+    final_layer, param_idx = ml.conv_layer(params, int(param_idx), conv_filters, poly_layer, x)
+    contract_layer, param_idx = ml.cascading_contractions(params, int(param_idx), x, final_layer, bias=False)
+    contract_layer = ml.leaky_relu_layer(contract_layer)
+
+    net_output = geom.linear_combination(contract_layer, params[param_idx:(param_idx + len(contract_layer))])
+    param_idx += len(contract_layer)
+    return (net_output, param_idx) if return_params else net_output
 
 def map_and_loss(params, x, y_steps, conv_filters):
     # Run x through the net, then return its loss with y
     loss = 0
-    for y in y_steps:
-        net_out = net(params, x, conv_filters)
-        x = x + net_out
-        loss += ml.rmse_loss(x, y)
+
+    if isinstance(y_steps, list): #if loss_steps is greater than 1
+        for y in y_steps:
+            net_out = net(params, x, conv_filters)
+            x = x + net_out
+            loss += ml.rmse_loss(x, y)
+    else:
+        loss = ml.rmse_loss(x + net(params, x, conv_filters), y_steps)
+
     return loss
 
 def handleArgs(argv):
@@ -44,7 +53,13 @@ def handleArgs(argv):
     parser.add_argument('-seed', help='the random number seed', type=int, default=None)
     parser.add_argument('-s', '--save', help='file name to save the params', type=str, default=None)
     parser.add_argument('-l', '--load', help='file name to load params from', type=str, default=None)
-    parser.add_argument('-noise', help='whether to add gaussian noise', default=False, action='store_true')
+    parser.add_argument(
+        '-noise',
+        help='standard deviation of Gaussian noise to add to training inputs', 
+        type=float, 
+        default=None,
+    )
+    parser.add_argument('-v', '--verbose', help='levels of print statements during training', type=int, default=1)
 
     args = parser.parse_args()
 
@@ -59,25 +74,28 @@ def handleArgs(argv):
         args.save,
         args.load,
         args.noise,
+        args.verbose,
     )
 
 #Main
 args = handleArgs(sys.argv)
-infile, outfile, epochs, lr, batch, loss_steps, seed, save_file, load_file, noise = args
+infile, outfile, epochs, lr, batch, loss_steps, seed, save_file, load_file, noise, verbose = args
 
 key = random.PRNGKey(time.time_ns()) if (seed is None) else random.PRNGKey(seed)
 
 ts = read_gif(infile)
 
 D = 2
-train_images = [geom.GeometricImage(frame, 0, D) for frame in ts]
+images = [geom.GeometricImage(frame, 0, D) for frame in ts]
+train_X, train_Y = ml.get_timeseries_XY(images, loss_steps=loss_steps, circular=True)
+test_images = train_X
 
 # start with basic 3x3 scalar, vector, and 2nd order tensor images
 group_actions = geom.make_all_operators(D)
 conv_filters = geom.get_invariant_filters(
     Ms=[3],
-    ks=[1,2],
-    parities=[0,1],
+    ks=[0],
+    parities=[0],
     D=D,
     operators=group_actions,
     return_list=True,
@@ -86,10 +104,11 @@ conv_filters = geom.get_invariant_filters(
 if load_file:
     params = jnp.load(load_file)
 else:
-    huge_params = jnp.ones(ml.param_count(train_images[0], conv_filters, 3))
+    huge_params = jnp.ones(10000)
+    
     _, num_params = net(
         huge_params, 
-        geom.BatchGeometricImage.from_images(train_images[:batch]), 
+        geom.BatchGeometricImage.from_images(train_X[:batch]), 
         conv_filters, 
         return_params=True,
     )
@@ -99,36 +118,31 @@ else:
     key, subkey = random.split(key)
     params = 0.1*random.normal(subkey, shape=(num_params,))
 
-    if noise:
-        # Add noise to help with longer rollouts
-        noisy_train_images = []
-        for x in train_images:
-            key, subkey = random.split(key)
-            noise = geom.GeometricImage(0.01*random.normal(subkey, shape=(x.shape())), x.parity, x.D)
-            noisy_train_images.append(x + noise)
-
     params = ml.train(
-        noisy_train_images if noise else train_images,
-        train_images,
+        train_X,
+        train_Y,
         partial(map_and_loss, conv_filters=conv_filters),
         params,
         key,
         epochs=epochs,
         batch_size=batch,
-        learning_rate=optax.linear_schedule(lr, lr/10, 40),
-        loss_steps=loss_steps,
+        optimizer=optax.adam(optax.exponential_decay(lr, transition_steps=24, decay_rate=0.98), b1=0.8, b2=0.99),
         save_params=save_file,
-    )
+        noise_stdev=noise,
+        verbose=verbose,
+    ) 
 
 if save_file:
     jnp.save(save_file, params)
 
-img = train_images[-1]
+img = test_images[-1]
 
+print("Rollout Loss:")
 frames = []
-for i in range(len(train_images)):
+for i in range(len(test_images)):
     net_out = net(params, img, conv_filters)
     img = img + net_out
+    print(f'Step {i}: {ml.rmse_loss(img, test_images[i], batch=False)}')
     frames.append(img.data)
 
 iio.imwrite(outfile, jnp.stack(frames))

--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -5,6 +5,7 @@ import numpy as np
 import math
 
 from jax import jit, random, value_and_grad
+import jax.nn
 import jax.numpy as jnp
 import optax
 
@@ -12,8 +13,8 @@ import geometricconvolutions.geometric as geom
 
 ## Layers
 
-@functools.partial(jit, static_argnums=1)
-def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None):
+@functools.partial(jit, static_argnums=[1,5])
+def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias=True):
     """
     Perform all the conv_filters on each image of input_layer. For efficiency, we take parameterized linear
     combinations of like inputs (same k and parity) before applying the convolutions. This is equivalent to a fully
@@ -27,6 +28,7 @@ def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None):
         conv_filters (list of GeometricFilters): all the filters we can apply
         input_layer (list of GeometricImages): linear, quadratic, cubic, etc. function image outputs
         target_x (GeometricImage): defaults to None, image that we are trying to return to
+        bias (bool): Whether to include a bias image, defaults to true
     """
     prods_dict = make_p_k_dict(input_layer)
     filters_dict = make_p_k_dict(conv_filters, filters=True) if target_x else None
@@ -44,11 +46,26 @@ def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None):
                 continue
 
             for conv_filter in filter_group:
+                if (bias):
+                    bias_img, param_idx = get_bias_image(params, param_idx, prods_group[0])
+                    prods_group.append(bias_img)
+
                 group_sum = geom.linear_combination(prods_group, params[param_idx:(param_idx + len(prods_group))])
                 out_layer.append(group_sum.convolve_with(conv_filter))
                 param_idx += len(prods_group)
 
     return out_layer, param_idx
+
+def get_bias_image(params, param_idx, x):
+    """
+    TODO: ensure this is working, for equivariance, the bias image must be invariant to the group.
+    """
+    fill = params[param_idx:(param_idx + (x.D ** x.k))].reshape((x.D,)*x.k)
+    param_idx += x.D ** x.k
+    if (x.__class__ == geom.BatchGeometricImage):
+        return x.__class__.fill(x.N, x.parity, x.D, fill, x.L), param_idx
+    elif (x.__class__ == geom.GeometricImage):
+        return x.__class__.fill(x.N, x.parity, x.D, fill), param_idx
 
 def make_p_k_dict(images, filters=False, rollup_set={}):
     """
@@ -73,65 +90,74 @@ def make_p_k_dict(images, filters=False, rollup_set={}):
 
     return images_dict
 
-def quad_fast(params, param_idx, images):
-    image_dict = make_p_k_dict(images)
+@jit
+def relu_layer(images):
+    return [image.activation_function(jax.nn.relu) for image in images]
 
+@jit
+def leaky_relu_layer(images, negative_slope=0.01):
+    leaky_relu = functools.partial(jax.nn.leaky_relu, negative_slope=negative_slope)
+    return [image.activation_function(leaky_relu) for image in images]
+
+@functools.partial(jit, static_argnums=[1,3,4])
+def polynomial_layer(params, param_idx, images, poly_degree, bias=True):
+    """
+    Construct a polynomial layer for a given degree. Calculate the full polynomial up to that degree of all the images.
+    For example, if poly_degree=3, calculate the linear, quadratic, and cubic terms.
+    args:
+        params (jnp.array): parameters
+        param_idx (int): index of current location in params
+        images (list of GeometricImages): the images to make the polynomial function
+        poly_degree (int): the maximum degree of the polynomial 
+        bias (bool): whether to include a constant bias image
+    """
+    out_layer_dict = defaultdict(list)
+
+    out_layer_dict[0] = images
+    for degree in range(1, poly_degree):
+        prev_images_dict = make_p_k_dict(out_layer_dict[degree - 1])
+
+        for img in images: #multiply by all the images
+            for parity in [0,1]:
+                for k in prev_images_dict[parity].keys():
+                    image_group = prev_images_dict[parity][k]
+                    if (len(image_group) == 0):
+                        continue
+
+                    if (bias):
+                        bias_img, param_idx = get_bias_image(params, param_idx, image_group[0])
+                        image_group.append(bias_img)
+
+                    group_sum = geom.linear_combination(image_group, params[param_idx:(param_idx + len(image_group))])
+                    out_layer_dict[degree].append(group_sum * img)
+                    param_idx += len(image_group)
+
+    return list(it.chain(*list(out_layer_dict.values()))), param_idx
+
+def order_cap_layer(images, max_k):
+    """
+    For each image with tensor order k larger than max_k, do all possible contractions to reduce it to order k, or k-1
+    if necessary because the difference is odd.
+    args:
+        images (list of GeometricImages): the input images in the layer
+        max_k (int): the max tensor order
+    """
     out_layer = []
     for img in images:
-        for parity in [0,1]:
-            for k in image_dict[parity].keys():
-                image_group = image_dict[parity][k]
-                if (len(image_group) == 0):
-                    continue
+        if (img.k > max_k):
+            k_diff = img.k - max_k 
+            if(k_diff % 2 == 1): #if its odd, we need to go one lower
+                k_diff += 1
 
-                group_sum = geom.linear_combination(image_group, params[param_idx:(param_idx + len(image_group))])
-                out_layer.append(group_sum * img)
-                param_idx += len(image_group)
-        
-    return out_layer, param_idx
+            for contract_idx in geom.get_contraction_indices(img.k, img.k - k_diff):
+                out_layer.append(img.multicontract(contract_idx))
+        else:
+            out_layer.append(img)
 
-@functools.partial(jit, static_argnums=[1,2,3])
-def prod_layer(images, degree, max_k=None, with_replace=True):
-    """
-    For the given degree, apply that many prods in all possible combinations with replacement of the images.
-    args:
-        images (list of GeometricImage): images to prod, these should be all the convolved images
-        degree (int): degree of the prods
-        max_k (int): the max tensor order of the products, contractions are applied if necessary after each prod
-        with_replace (bool): whether prods should be combos w/ replacement, or combos w/o replacement, defaults to true
-    """
-    if with_replace:
-        idx_generator = it.combinations_with_replacement(range(len(images)), degree)
-    else:
-        idx_generator = it.combinations(range(len(images)), degree)
+    return out_layer
 
-    prods = []
-    for idxs in idx_generator: #multiply the images one at a time so we can limit k
-        rolling_prods = [images[idxs[0]]]
-        for idx in idxs[1:]:
-            next_prods = []
-            for prev_prod in rolling_prods:
-                rolling_prod = prev_prod * images[idx]
-
-                if (max_k and (rolling_prod.k > max_k)):
-                    k_diff = rolling_prod.k - max_k 
-                    if(k_diff % 2 == 1): #if its odd, we need to go one lower
-                        k_diff += 1
-
-                    for contract_idx in geom.get_contraction_indices(rolling_prod.k, rolling_prod.k - k_diff):
-                        next_prods.append(rolling_prod.multicontract(contract_idx))
-                else:
-                    next_prods.append(rolling_prod)
-
-            rolling_prods = next_prods
-
-        prods.extend(rolling_prods)
-
-    # print(len(prods))
-    return prods
-
-@functools.partial(jit, static_argnums=1)
-def cascading_contractions(params, param_idx, x, input_layer):
+@functools.partial(jit, static_argnums=[1,4])
+def cascading_contractions(params, param_idx, x, input_layer, bias=True):
     """
     Starting with the highest k, sum all the images into a single image, perform all possible contractions,
     then add it to the layer below.
@@ -140,6 +166,7 @@ def cascading_contractions(params, param_idx, x, input_layer):
         param_idx (int): index of current location in params
         x (GeometricImage): image that is going through the model
         input_layer (list of GeometricImages): images to contract
+        bias (bool): whether to include a constant bias image
     """
     images_by_k = defaultdict(list)
     max_k = np.max([img.k for img in input_layer])
@@ -148,6 +175,10 @@ def cascading_contractions(params, param_idx, x, input_layer):
 
     for k in reversed(range(x.k+2, max_k+2, 2)):
         images = images_by_k[k]
+
+        if (bias):
+            bias_img, param_idx = get_bias_image(params, param_idx, images[0])
+            images.append(bias_img)
 
         for u,v in it.combinations(range(k), 2):
             group_sum = geom.linear_combination(images, params[param_idx:(param_idx + len(images))])
@@ -176,7 +207,7 @@ def param_count(x, conv_filters, deg):
 
     return math.comb(len(conv_filters)+deg-1, deg) * len(conv_filters) * math.comb((max_k**(deg+1))+(x.k**deg), 2)
 
-## Other
+## Losses
 
 def rmse_loss(x, y, batch=True):
     """
@@ -189,6 +220,8 @@ def rmse_loss(x, y, batch=True):
     axes = tuple(range(1, len(x.shape()))) if batch else None
     rmse = jnp.sqrt(jnp.sum((x.data - y.data) ** 2, axis=axes))
     return jnp.mean(rmse) if batch else rmse
+
+## Data and Batching operations
 
 def get_batch_channel(Xs, Ys, batch_size, rand_key):
     """
@@ -242,7 +275,7 @@ def get_batch(X, Y_steps, batch_size, rand_key):
     X_batch, Y_batch = get_batch_channel([X], [Y_steps], batch_size, rand_key)
     return X_batch[0], Y_batch[0]
 
-def get_batch_rollout(X, Y, batch_size, rand_key, rollout=1):
+def get_batch_rollout(X, Y, batch_size, rand_key):
     """
     Given X, Y, construct a random batch of batch size. Each Y_batch is a list of length rollout to allow for
     calculating the loss with each step of the rollout.
@@ -253,23 +286,63 @@ def get_batch_rollout(X, Y, batch_size, rand_key, rollout=1):
         rand_key (jnp random key): key for the randomness
         rollout (int): number of steps of rollout to do for Y
     """
-    data_len = len(X) - rollout
-    assert batch_size <= data_len
-    batch_indices = random.permutation(rand_key, data_len)
+    batch_indices = random.permutation(rand_key, len(X))
 
     X_batches = []
     Y_batches = []
-    for i in range(int(math.ceil(data_len / batch_size))): #iterate through the batches of an epoch
+    for i in range(int(math.ceil(len(X) / batch_size))): #iterate through the batches of an epoch
         idxs = batch_indices[i*batch_size:(i+1)*batch_size]
         X_batches.append(geom.BatchGeometricImage.from_images(X, idxs))
 
-        Y_batch_steps = []
-        for step_size in range(1,rollout+1): #iterate through the number of steps we are rolling out
-            Y_batch_steps.append(geom.BatchGeometricImage.from_images(Y[step_size:], idxs))
+        if (isinstance(Y[0], list)): # there are multiple loss steps
+            Y_batch_steps = []
+            for step_size in range(len(Y[0])): #iterate through the number of steps we are rolling out
+                Y_at_step = [y[step_size] for y in Y]
+                Y_batch_steps.append(geom.BatchGeometricImage.from_images(Y_at_step, idxs))
 
-        Y_batches.append(Y_batch_steps)
+            Y_batches.append(Y_batch_steps)
+        else: #if there is just a single loss step            
+            Y_batches.append(geom.BatchGeometricImage.from_images(Y, idxs))
 
     return X_batches, Y_batches
+
+def add_noise(X, stdev, rand_key):
+    """
+    Add mean 0, stdev standard deviation Gaussian noise to the data X.
+    args:
+        X (list of GeometricImages): the X input data to the model
+        stdev (float): the standard deviation of the desired Gaussian noise
+        rand_key (jnp.random key): the key for randomness
+    """
+    noise = stdev*random.normal(rand_key, shape=(len(X),) + X[0].shape())
+    return [x + geom.GeometricImage(noise, x.parity, x.D) for x, noise in zip(X, noise)]
+
+def get_timeseries_XY(X, loss_steps=1, circular=False):
+    """
+    Given data X that is a time series, we want to form Y that is one step in the timeseries. If loss_steps is 1,
+    then this function will return a list of GeometricImages. If loss steps is greater than 1, this function will
+    return a list of lists where the inner list is the sequence of steps. If circular is true, then the end of the
+    time series feeds directly into the beginning.
+    args:
+        X (list of GeometricImages): GeometricImages of the time series
+        loss_steps (int): how many steps in our loss, defaults to 1
+        circular (bool): whether the time series is circular, defaults to False
+    """
+    assert loss_steps >= 1
+    data_len = len(X) if circular else (len(X) - loss_steps)
+
+    Y = []
+    for i in range(data_len):
+        if (loss_steps == 1):
+            Y.append(X[(i + 1) % len(X)])
+        else:
+            Y_steps = []
+            for step_size in range(1, loss_steps + 1): #iterate through the number of steps we are rolling out
+                Y_steps.append(X[(i + step_size) % len(X)])
+
+            Y.append(Y_steps)
+
+    return X[:data_len], Y
 
 ### Train
 
@@ -281,8 +354,8 @@ def train(
     rand_key, 
     epochs, 
     batch_size=16, 
-    learning_rate=0.1, 
-    loss_steps=1, 
+    optimizer=None,
+    noise_stdev=None, 
     save_params=None,
     verbose=1,
 ):
@@ -299,8 +372,9 @@ def train(
         epochs (int): number of epochs to run. An epoch is defined as a pass over the entire data, and may involve
             multiple batches.
         batch_size (int): defaults to 16, the size of each mini-batch in SGD
-        learning rate (float or optax learning rate schedule): defaults to 0.1, the lr provided to optax Adam
+        optimizer (optax optimizer): optimizer, defaults to adam(learning_rate=0.1)
         loss_steps (int): defaults to 1, the number of steps to rollout the prediction when computing the loss.
+        noise_stdev (float): standard deviation for any noise to add to training data, defaults to None
         save_params (str): defaults to None, where to save the params of the model, every epochs/10 th epoch.
         verbose (0,1,2 or 3): verbosity level. 3 prints loss every batch, 2 every epoch, 1 ever epochs/10 th epoch
             0 not at all.
@@ -308,13 +382,21 @@ def train(
     assert verbose in {0,1,2,3}
     batch_loss_grad = value_and_grad(map_and_loss)
 
-    optimizer = optax.adam(learning_rate)
+    if (optimizer is None):
+        optimizer = optax.adam(0.1)
+
     opt_state = optimizer.init(params)
 
     for i in range(epochs):
         rand_key, subkey = random.split(rand_key)
 
-        X_batches, Y_batches = get_batch_rollout(X, Y, batch_size, subkey, loss_steps)
+        if noise_stdev:
+            train_X = add_noise(X, noise_stdev, subkey)
+            rand_key, subkey = random.split(rand_key)
+        else:
+            train_X = X
+
+        X_batches, Y_batches = get_batch_rollout(train_X, Y, batch_size, subkey)
         epoch_loss = 0
         for X_batch, Y_batch_steps in zip(X_batches, Y_batches):
             loss_val, grads = batch_loss_grad(params, X_batch, Y_batch_steps)

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,0 +1,63 @@
+import jax.numpy as jnp
+from jax import random
+
+import geometricconvolutions.geometric as geom
+import geometricconvolutions.ml as ml
+
+class TestMachineLearning:
+    # Class to test the functions in the ml.py file, which include layers, data pre-processing, batching, etc.
+
+    def testGetTimeSeriesXY(self):
+        N = 5
+        parity = 0
+        D = 2
+        ts = [geom.GeometricImage.fill(N, parity, D, fill_val) for fill_val in jnp.arange(10)]
+
+        # regular
+        X,Y = ml.get_timeseries_XY(ts, loss_steps=1, circular=False)
+        assert len(X) == len(Y) == (len(ts)-1)
+        for i in range(len(ts)-1):
+            assert ts[i] == X[i] == Y[i]
+
+        # loss_steps = 3
+        X,Y = ml.get_timeseries_XY(ts, loss_steps=3, circular=False)
+        assert X[0].__class__ == geom.GeometricImage
+        assert isinstance(Y[0], list)
+        assert len(Y[2]) == 3
+        assert Y[3][0] == ts[4]
+        assert Y[3][1] == ts[5]
+        assert Y[3][2] == ts[6]
+        assert Y[5][1] == Y[6][0]
+        assert len(X) == len(Y) == (len(ts)-3)
+
+        # circular
+        X,Y = ml.get_timeseries_XY(ts, loss_steps=1, circular=True)
+        assert len(X) == len(Y) == len(ts)
+        assert X[-1] == ts[-1]
+        assert Y[-1] == X[0]
+
+        #circular, loss_steps=2
+        X,Y = ml.get_timeseries_XY(ts, loss_steps=2, circular=True)
+        assert len(X) == len(Y) == len(ts)
+        assert len(Y[3]) == 2
+        assert Y[-1][0] == X[0]
+        assert Y[-1][1] == X[1]
+        assert Y[-2][0] == X[-1]
+        assert Y[-2][1] == X[0]
+
+    def testGetBatchRollout(self):
+        key = random.PRNGKey(0)
+        N = 5
+        parity = 0
+        D = 2
+        ts = [geom.GeometricImage.fill(N, parity, D, fill_val) for fill_val in jnp.arange(11)]
+
+        X,Y = ml.get_timeseries_XY(ts, loss_steps=1, circular=False)
+
+        batch_size = 2
+        X_batches, Y_batches = ml.get_batch_rollout(X, Y, batch_size=batch_size, rand_key=key)
+        assert len(X_batches) == len(Y_batches) == 5
+        for X_batch, Y_batch in zip(X_batches, Y_batches):
+            assert X_batch.L == Y_batch.L == 2
+            assert (X_batch + geom.BatchGeometricImage.fill(N, parity, D, 1, batch_size)) == Y_batch
+


### PR DESCRIPTION
## Changes
- add activation functions. Currently these only work for k=0 tensors to preserve the equivariance
- add bias images. Currently these only for k=0 tensors for equivariance
- add verbose parameter
- change model to only use scalar filters. For seed=0 at least, this seems sufficient to get pretty good results. This could just be a training issue when using the more advanced filters/layers.
- move noise addition to train so that the noise is different every epoch
- add fill constructor for GeometricImage and BatchGeometricImage
- rework prod_layer into polynomial_layer, uses faster process with linear combinations before multiplying

## Testing
- ran gif_example script
- added new test cases for ml.py
- ran pytest

## Doc Changes
- None