### PR TITLE
add gravity script, dilations

### DIFF
--- a/scripts/gif_example.py
+++ b/scripts/gif_example.py
@@ -142,7 +142,7 @@ frames = []
 for i in range(len(test_images)):
     net_out = net(params, img, conv_filters)
     img = img + net_out
-    print(f'Step {i}: {ml.rmse_loss(img, test_images[i], batch=False)}')
+    print(f'Step {i}: {ml.rmse_loss(img, test_images[i])}')
     frames.append(img.data)
 
 iio.imwrite(outfile, jnp.stack(frames))

--- a/scripts/gravity_field.py
+++ b/scripts/gravity_field.py
@@ -191,4 +191,3 @@ print(f'One Test loss: {map_and_loss(params, test_X[0], test_Y[0], conv_filters)
 utils.plot_image(net(params, test_X[0], conv_filters, test_Y[0]), ax=axs[1,2])
 
 plt.savefig(outfile)
-# plt.savefig('../images/gravity/gravity_test.png')

--- a/scripts/gravity_field.py
+++ b/scripts/gravity_field.py
@@ -1,0 +1,186 @@
+#generate gravitational field
+import sys
+import numpy as np
+import itertools as it
+from functools import partial
+import argparse
+import time
+import matplotlib.pyplot as plt
+
+import jax.numpy as jnp
+import jax.random as random
+import optax
+
+import geometricconvolutions.geometric as geom
+import geometricconvolutions.ml as ml
+import geometricconvolutions.utils as utils
+
+def get_gravity_vector(position1, position2, mass):
+    r_vec = position1 - position2
+    r_squared = np.linalg.norm(r_vec) ** 2
+    return (mass / r_squared) * r_vec
+
+def get_gravity_field_image(N, D, point_position, point_mass):
+    field = np.zeros((N,)*D + (D,))
+
+    # this could all be vectorized
+    for position in it.product(range(N), repeat=D):
+        position = np.array(position)
+        if (np.all(position == point_position)):
+            continue
+
+        field[tuple(position)] = get_gravity_vector(point_position, position, point_mass)
+
+    return geom.GeometricImage(field, 0, D, is_torus=False)
+
+def get_data(N, D, num_points, rand_key, num_images=1):
+    rand_key, subkey = random.split(rand_key)
+    planets = random.uniform(subkey, shape=(num_points,))
+    planets = planets / jnp.max(planets)
+
+    masses = []
+    gravity_fields = []
+    for _ in range(num_images):
+        point_mass = np.zeros((N,N))
+        gravity_field = geom.GeometricImage.zeros(N=N, k=1, parity=0, D=D, is_torus=False)
+
+        # Sample uniformly the cells
+        rand_key, subkey = random.split(rand_key)
+        possible_locations = np.array(list(it.product(range(N), repeat=D)))
+        location_choices = random.choice(subkey, possible_locations, shape=(num_points,), replace=False, axis=0)
+        for (x,y), mass in zip(location_choices, planets):
+            point_mass[x,y] = mass
+            gravity_field = gravity_field + get_gravity_field_image(N, D, np.array([x,y]), mass)
+
+        masses.append(geom.GeometricImage(point_mass, 0, D, is_torus=False))
+        gravity_fields.append(gravity_field)
+
+    return masses, gravity_fields
+
+def net(params, x, conv_filters, target_img, return_params=False):
+    # Note that the target image is only used for its shape
+    layer, param_idx = ml.conv_layer(params, 0, conv_filters, [x])
+    layer, param_idx = ml.conv_layer(params, int(param_idx), conv_filters, layer, dilations=tuple(range(x.N)))
+
+    layer, param_idx = ml.conv_layer(params, int(param_idx), conv_filters, layer, target_img, dilations=tuple(range(int(x.N / 2))))
+    layer, param_idx = ml.cascading_contractions(params, int(param_idx), target_img, layer)
+
+    net_output = geom.linear_combination(layer, params[param_idx:(param_idx + len(layer))])
+    param_idx += len(layer)
+    return (net_output, param_idx) if return_params else net_output
+
+def map_and_loss(params, x, y, conv_filters):
+    # Run x through the net, then return its loss with y
+    return ml.rmse_loss(net(params, x, conv_filters, y), y)
+
+def handleArgs(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-e', '--epochs', help='number of epochs to run', type=int, default=10)
+    parser.add_argument('-lr', help='learning rate', type=float, default=0.1)
+    parser.add_argument('-batch', help='batch size', type=int, default=1)
+    parser.add_argument('-seed', help='the random number seed', type=int, default=None)
+    parser.add_argument('-s', '--save', help='file name to save the params', type=str, default=None)
+    parser.add_argument('-l', '--load', help='file name to load params from', type=str, default=None)
+    parser.add_argument('-v', '--verbose', help='levels of print statements during training', type=int, default=1)
+
+    args = parser.parse_args()
+
+    return (
+        args.epochs,
+        args.lr,
+        args.batch,
+        args.seed,
+        args.save,
+        args.load,
+        args.verbose,
+    )
+
+# Main
+epochs, lr, batch_size, seed, save_file, load_file, verbose = handleArgs(sys.argv)
+
+N = 16
+D = 2
+num_points = 5
+num_train_images = 5
+num_test_images = 10
+num_val_images = 5
+
+key = random.PRNGKey(seed if seed else time.time_ns())
+
+key, subkey = random.split(key)
+validation_X, validation_Y = get_data(N, D, num_points, subkey, num_val_images)
+
+key, subkey = random.split(key)
+test_X, test_Y = get_data(N, D, num_points, subkey, num_test_images)
+
+key, subkey = random.split(key)
+train_X, train_Y = get_data(N, D, num_points, subkey, num_train_images)
+
+# start with basic 3x3 scalar, vector, and 2nd order tensor images
+group_actions = geom.make_all_operators(D)
+conv_filters = geom.get_invariant_filters(
+    Ms=[3],
+    ks=[0,1],
+    parities=[0],
+    D=D,
+    operators=group_actions,
+    return_list=True,
+)
+
+if load_file:
+    params = jnp.load(load_file)
+else:
+    huge_params = jnp.ones(100000)
+
+    _, num_params = net(
+        huge_params,
+        geom.BatchGeometricImage.from_images(train_X),
+        conv_filters,
+        train_Y[0],
+        return_params=True,
+    )
+
+    print('Num params:', num_params)
+
+    key, subkey = random.split(key)
+    params = 0.1*random.normal(subkey, shape=(num_params,))
+
+    params = ml.train(
+        train_X,
+        train_Y,
+        partial(map_and_loss, conv_filters=conv_filters),
+        params,
+        key,
+        epochs=epochs,
+        batch_size=batch_size,
+        optimizer=optax.adam(optax.exponential_decay(lr, transition_steps=int(len(train_X) / batch_size), decay_rate=0.995)),
+        # optimizer=optax.adam(lr),
+        validation_X=validation_X,
+        validation_Y=validation_Y,
+        save_params=save_file,
+        # noise_stdev=noise,
+        verbose=verbose,
+    )
+
+    if (save_file):
+            jnp.save(save_file, params)
+
+fig, axs = plt.subplots(nrows=2, ncols=3, figsize=(24,12))
+
+utils.plot_image(train_X[0], ax=axs[0,0])
+utils.plot_image(train_Y[0], ax=axs[0,1])
+utils.plot_image(net(params, train_X[0], conv_filters, train_Y[0]), ax=axs[0,2])
+
+utils.plot_image(test_X[0], ax=axs[1,0])
+utils.plot_image(test_Y[0], ax=axs[1,1])
+test_loss = map_and_loss(
+    params, 
+    geom.BatchGeometricImage.from_images(test_X), 
+    geom.BatchGeometricImage.from_images(test_Y), 
+    conv_filters,
+)
+print('Full Test loss:', test_loss)
+print(f'One Test loss: {map_and_loss(params, test_X[0], test_Y[0], conv_filters)}')
+utils.plot_image(net(params, test_X[0], conv_filters, test_Y[0]), ax=axs[1,2])
+
+plt.savefig('../images/gravity/gravity_test.png')

--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -14,7 +14,7 @@ import geometricconvolutions.geometric as geom
 ## Layers
 
 @functools.partial(jit, static_argnums=[1,5,6])
-def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias=False, dilations=(None,)):
+def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias=False, dilations=(1,)):
     """
     Perform all the conv_filters on each image of input_layer. For efficiency, we take parameterized linear
     combinations of like inputs (same k and parity) before applying the convolutions. This is equivalent to a fully
@@ -29,7 +29,7 @@ def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias
         input_layer (list of GeometricImages): linear, quadratic, cubic, etc. function image outputs
         target_x (GeometricImage): defaults to None, image that we are trying to return to
         bias (bool): Whether to include a bias image, defaults to False
-        dilations (list of ints): the dilation convolutions to perform, defaults to (None,) (equivalent to (1,))
+        dilations (list of ints): the dilation convolutions to perform, defaults to (1,), or normal dilation
     """
     prods_dict = make_p_k_dict(input_layer)
     filters_dict = make_p_k_dict(conv_filters, filters=True) if target_x else None

--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -13,8 +13,8 @@ import geometricconvolutions.geometric as geom
 
 ## Layers
 
-@functools.partial(jit, static_argnums=[1,5])
-def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias=True):
+@functools.partial(jit, static_argnums=[1,5,6])
+def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias=False, dilations=(None,)):
     """
     Perform all the conv_filters on each image of input_layer. For efficiency, we take parameterized linear
     combinations of like inputs (same k and parity) before applying the convolutions. This is equivalent to a fully
@@ -28,7 +28,8 @@ def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias
         conv_filters (list of GeometricFilters): all the filters we can apply
         input_layer (list of GeometricImages): linear, quadratic, cubic, etc. function image outputs
         target_x (GeometricImage): defaults to None, image that we are trying to return to
-        bias (bool): Whether to include a bias image, defaults to true
+        bias (bool): Whether to include a bias image, defaults to False
+        dilations (list of ints): the dilation convolutions to perform, defaults to (None,) (equivalent to (1,))
     """
     prods_dict = make_p_k_dict(input_layer)
     filters_dict = make_p_k_dict(conv_filters, filters=True) if target_x else None
@@ -46,13 +47,14 @@ def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias
                 continue
 
             for conv_filter in filter_group:
-                if (bias and k == 0):
-                    bias_img, param_idx = get_bias_image(params, param_idx, prods_group[0])
-                    prods_group.append(bias_img)
+                for dilation in dilations:
+                    if (bias and k == 0):
+                        bias_img, param_idx = get_bias_image(params, param_idx, prods_group[0])
+                        prods_group.append(bias_img)
 
-                group_sum = geom.linear_combination(prods_group, params[param_idx:(param_idx + len(prods_group))])
-                out_layer.append(group_sum.convolve_with(conv_filter))
-                param_idx += len(prods_group)
+                    group_sum = geom.linear_combination(prods_group, params[param_idx:(param_idx + len(prods_group))])
+                    out_layer.append(group_sum.convolve_with(conv_filter, dilation=dilation))
+                    param_idx += len(prods_group)
 
     return out_layer, param_idx
 
@@ -68,9 +70,9 @@ def get_bias_image(params, param_idx, x):
     fill = params[param_idx:(param_idx + (x.D ** x.k))].reshape((x.D,)*x.k)
     param_idx += x.D ** x.k
     if (x.__class__ == geom.BatchGeometricImage):
-        return x.__class__.fill(x.N, x.parity, x.D, fill, x.L), param_idx
+        return x.__class__.fill(x.N, x.parity, x.D, fill, x.L, x.is_torus), param_idx
     elif (x.__class__ == geom.GeometricImage):
-        return x.__class__.fill(x.N, x.parity, x.D, fill), param_idx
+        return x.__class__.fill(x.N, x.parity, x.D, fill, x.is_torus), param_idx
 
 def make_p_k_dict(images, filters=False, rollup_set={}):
     """
@@ -161,7 +163,7 @@ def order_cap_layer(images, max_k):
 
     return out_layer
 
-@functools.partial(jit, static_argnums=[1,4])
+@functools.partial(jit, static_argnums=1)
 def cascading_contractions(params, param_idx, x, input_layer):
     """
     Starting with the highest k, sum all the images into a single image, perform all possible contractions,
@@ -209,14 +211,15 @@ def param_count(x, conv_filters, deg):
 
 ## Losses
 
-def rmse_loss(x, y, batch=True):
+def rmse_loss(x, y):
     """
-    Root Mean Squared Error Loss, defaults to expecting BatchGeometricImages
+    Root Mean Squared Error Loss, if x and y are both batches, the loss is per image.
     args:
         x (GeometricImage): the input image
         y (GeometricImage): the associated output for x that we are comparing against
-        batch (bool): whether x and y are BatchGeometricImages, defaults to True
     """
+    assert isinstance(x, geom.BatchGeometricImage) == isinstance(y, geom.BatchGeometricImage)
+    batch = isinstance(x, geom.BatchGeometricImage)
     axes = tuple(range(1, len(x.shape()))) if batch else None
     rmse = jnp.sqrt(jnp.sum((x.data - y.data) ** 2, axis=axes))
     return jnp.mean(rmse) if batch else rmse
@@ -355,6 +358,8 @@ def train(
     epochs, 
     batch_size=16, 
     optimizer=None,
+    validation_X=None,
+    validation_Y=None,
     noise_stdev=None, 
     save_params=None,
     verbose=1,
@@ -373,6 +378,8 @@ def train(
             multiple batches.
         batch_size (int): defaults to 16, the size of each mini-batch in SGD
         optimizer (optax optimizer): optimizer, defaults to adam(learning_rate=0.1)
+        validation_X (list of GeometricImages): input data for a validation data set
+        validation_Y (list of GeometricImages): target data for a validation data set
         loss_steps (int): defaults to 1, the number of steps to rollout the prediction when computing the loss.
         noise_stdev (float): standard deviation for any noise to add to training data, defaults to None
         save_params (str): defaults to None, where to save the params of the model, every epochs/10 th epoch.
@@ -411,6 +418,10 @@ def train(
                 jnp.save(save_params, params)
             if (verbose == 1):
                 print(f'Epoch {i}: {epoch_loss / len(X_batches)}')
+            if (validation_X and validation_Y):
+                batch_validation_X = geom.BatchGeometricImage.from_images(validation_X)
+                batch_validation_Y = geom.BatchGeometricImage.from_images(validation_Y)
+                print('Validation Error: ', map_and_loss(params, batch_validation_X, batch_validation_Y))
 
         if (verbose >= 2):
             print(f'Epoch {i}: {epoch_loss / len(X_batches)}')

--- a/src/geometricconvolutions/utils.py
+++ b/src/geometricconvolutions/utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pylab as plt
 import matplotlib.cm as cm
-from matplotlib.colors import ListedColormap
 import cmastro
 from geometricconvolutions.geometric import TINY
 

--- a/tests/test_geometric_image.py
+++ b/tests/test_geometric_image.py
@@ -59,6 +59,7 @@ class TestGeometricImage:
         assert image1.data.shape == (10,10)
         assert image1.D == 2
         assert image1.k == 0
+        assert image1.is_torus
 
         image2 = geom.GeometricImage(random.uniform(key, shape=(10,10,2)), 0, 2)
         assert image2.data.shape == (10,10,2)
@@ -69,6 +70,9 @@ class TestGeometricImage:
         assert image3.data.shape == (10,10,2,2,2)
         assert image3.k == 3
         assert image3.parity == 1
+
+        image4 = geom.GeometricImage(random.uniform(key, shape=(10,10,10)), 0, 3, False)
+        assert not image4.is_torus
 
         #D does not match dimensions
         with pytest.raises(AssertionError):
@@ -83,7 +87,7 @@ class TestGeometricImage:
             geom.GeometricImage(random.uniform(key, shape=(10,10,3,3)), 0, 2)
 
     def testCopy(self):
-        image1 = geom.GeometricImage.zeros(20,0,0,2)
+        image1 = geom.GeometricImage.zeros(20,0,0,2,False)
         image2 = image1.copy()
 
         assert type(image1) == type(image2)
@@ -92,6 +96,7 @@ class TestGeometricImage:
         assert image1.D == image2.D
         assert image1.k == image2.k
         assert image1.N == image2.N
+        assert image1.is_torus == image2.is_torus
         assert image1 == image2
 
     def testEqual(self):
@@ -120,6 +125,10 @@ class TestGeometricImage:
         # different parity
         img8 = geom.GeometricImage(jnp.ones((10,10,2)), 1, 2)
         assert img1 != img8
+
+        # different is_torus
+        img9 = geom.GeometricImage(jnp.ones((10,10,2)), 0, 2, False)
+        assert img1 != img9
 
         #different data
         img9 = geom.GeometricImage(2*jnp.ones((10,10,2)), 0, 2)
@@ -159,6 +168,10 @@ class TestGeometricImage:
         image5 = geom.GeometricImage(jnp.ones((20,20,2), dtype=int), 0, 2)
         with pytest.raises(AssertionError): #N not equal
             result = image1 + image5
+
+        image6 = geom.GeometricImage(jnp.ones((10,10,2)), 0, 2, False)
+        with pytest.raises(AssertionError): # is_torus not equal
+            result = image1 + image6
 
     def testSub(self):
         image1 = geom.GeometricImage(jnp.ones((10,10,2), dtype=int), 0, 2)
@@ -526,6 +539,17 @@ class TestGeometricImage:
             [[3,0],[-3,1],[0,-1]],
             [[-1,-2],[-1,-1],[2,-3]]
         ], dtype=float)).all()
+
+    def testConvolveNonTorus(self):
+        """
+        Convolve where the GeometricImage is not a torus.
+        """
+        image1 = geom.GeometricImage(jnp.array([[2,1,0], [0,0,-3], [2,0,1]], dtype=float), 0, 2, False)
+        filter_image = geom.GeometricFilter(jnp.array([[1,0,1],[0,0,0],[1,0,1]], dtype=float), 0, 2)
+
+        convolved_image = image1.convolve_with(filter_image)
+        assert not convolved_image.is_torus 
+        assert jnp.allclose(convolved_image.data, jnp.array([[0,-3,0], [1,5,1], [0,-3,0]]))
 
     def testTimesGroupElement(self):
         left90 = jnp.array([[0,-1],[1,0]])

--- a/tests/test_geometric_image.py
+++ b/tests/test_geometric_image.py
@@ -551,6 +551,43 @@ class TestGeometricImage:
         assert not convolved_image.is_torus 
         assert jnp.allclose(convolved_image.data, jnp.array([[0,-3,0], [1,5,1], [0,-3,0]]))
 
+    def testConvolveDilation(self):
+        """
+        Convolve where the Geometric Image is a torus, but we dilate the filter.
+        """
+        image1 = geom.GeometricImage(jnp.array([[2,1,0], [0,0,-3], [2,0,1]], dtype=float), 0, 2)
+        filter_image = geom.GeometricFilter(jnp.array([[1,0,2],[1,-1,0],[0,0,-2]], dtype=float), 0, 2)
+
+        convolved_image = image1.convolve_with(filter_image, dilation=2)
+        assert jnp.allclose(convolved_image.data, jnp.array([[-9,-8,2], [2,-2,3], [5,5,5]]))
+
+    def testConvolveDilationNonTorus(self):
+        """
+        Convolve where the Geometric Image is not a torus and we dilate the filter.
+        """
+        image1 = geom.GeometricImage(
+            jnp.array([
+                [2,1,0,1,0], 
+                [0,0,-3,2,-2], 
+                [2,0,1,0,1],
+                [1,0,1,2,2],
+                [-1,-1,0,0,0],
+            ], dtype=float),
+            0,
+            2,
+            is_torus=False,
+        )
+        filter_image = geom.GeometricFilter(jnp.array([[1,0,2],[1,-1,0],[0,0,-2]], dtype=float), 0, 2)
+
+        convolved_image = image1.convolve_with(filter_image, dilation=2)
+        assert jnp.allclose(convolved_image.data, jnp.array([
+            [-4,-1,0,0,0], 
+            [-2,-4,-1,-2,-1], 
+            [-2,2,3,1,0],
+            [-7,4,-4,-2,-4],
+            [3,1,3,-1,1],
+        ]))
+
     def testTimesGroupElement(self):
         left90 = jnp.array([[0,-1],[1,0]])
         flipX = jnp.array([[-1, 0], [0,1]])

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -17,7 +17,9 @@ class TestMachineLearning:
         X,Y = ml.get_timeseries_XY(ts, loss_steps=1, circular=False)
         assert len(X) == len(Y) == (len(ts)-1)
         for i in range(len(ts)-1):
-            assert ts[i] == X[i] == Y[i]
+            assert ts[i] == X[i]
+            if i > 0:
+                assert X[i] == Y[i-1]
 
         # loss_steps = 3
         X,Y = ml.get_timeseries_XY(ts, loss_steps=3, circular=False)


### PR DESCRIPTION
## Changes
- infer the batch or not batch nature of x and y in RMSE loss
- allow GeometricImages to not be on the torus. This is specified at construction, and all binary operators that return a new image require them both to either be on the torus, or not on the torus.
- allow convolutions to have optional dilations of the filter
- default to no bias image in ml layers
- add validation data set to ml.train, it prints the val loss every 1/10th of the way
- add example script for the gravity field problem

## Testing
- ran scripts
- added some tests

## Doc Changes