### PR TITLE
add pooling, unpooling layers, make convolve_with more flexible

### DIFF
--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -26,7 +26,7 @@ import numpy as np #removing this
 import jax.numpy as jnp
 import jax.lax
 import jax.nn
-from jax import jit
+from jax import jit, vmap
 from jax.tree_util import register_pytree_node_class
 from functools import partial
 
@@ -414,12 +414,14 @@ class GeometricImage:
         """
         return self.data.shape
 
-    def image_shape(self):
+    def image_shape(self, plus_N=0):
         """
         Return the shape of the data block that is not the ktensor shape, but what comes before that. For regular
         GeometricImages, this is shape of the literal image. For BatchGeometricImage it prepends the batch size L.
+        args:
+            plus_N (int): numer to add to self.N, useful when growing/shrinking the image
         """
-        return self.D*(self.N,)
+        return self.D*(self.N + plus_N,)
 
     def pixel_shape(self):
         """
@@ -586,7 +588,15 @@ class GeometricImage:
         return image_data.reshape((1,) + image_shape + (channel_length,))
 
     partial(jit, static_argnums=2)
-    def convolve_with(self, filter_image, dilation=1, warnings=True):
+    def convolve_with(
+        self, 
+        filter_image, 
+        stride=None, 
+        padding=None,
+        lhs_dilation=None, 
+        rhs_dilation=None, 
+        warnings=True,
+    ):
         """
         Here is how this function works:
         1. Expand the geom_image to its torus shape, i.e. add filter.m cells all around the perimeter of the image
@@ -603,10 +613,12 @@ class GeometricImage:
 
         args:
             filter_image (GeometricFilter): the filter we are performing the convolution with
-            dilation (int): amount of dilation to apply to image during convolution, defaults to 1
+            stride (tuple of ints): convolution stride, defaults to (1,)*self.D
+            padding (one of 'TORUS','VALID', or 'SAME'): defaults to 'TORUS' if image.is_torus, else 'SAME'
+            lhs_dilation (tuple of ints): amount of dilation to apply to image in each dimension D, also transposed conv
+            rhs_dilation (tuple of ints): amount of dilation to apply to filter in each dimension D, defaults to 1
             warnings (bool): display warnings, defaults to True currently
         """
-        assert dilation > 0
         if (self.data.dtype != filter_image.data.dtype):
             dtype = 'float32'
             if (warnings):
@@ -616,17 +628,29 @@ class GeometricImage:
 
         output_k = self.k + filter_image.k
 
-        rhs_dilation = (dilation,)*self.D if dilation else None
+        if rhs_dilation is None:
+            rhs_dilation = (1,)*self.D
 
-        # if the image is on the torus, we expand the data so we can convolve with valid. Else, we will pad w/ 0s
-        if self.is_torus:
-            torus_expand_img = self.get_torus_expanded(filter_image, dilation)
-            padding_mode = ((0,0),)*self.D #equivalent to 'VALID'
+        if stride is None:
+            stride = (1,)*self.D
+
+        if not padding: #if unspecified, infer from self.is_torus
+            padding = 'TORUS' if self.is_torus else 'SAME'
+
+        # output_image_shape = (self.N,)*self.D
+        if padding == 'TORUS':
+            image = self.get_torus_expanded(filter_image, rhs_dilation[0])
+            padding_literal = ((0,0),)*self.D
         else:
-            torus_expand_img = self #not on the torus, don't need to expand at all, just pad with zeros
-            padding_mode = ((filter_image.m*dilation,)*2,)*self.D #equivalent to 'SAME', pad w/ 0s
+            image = self
+            if padding == 'VALID':
+                padding_literal = ((0,0),)*self.D
+            elif padding == 'SAME':
+                padding_literal = ((filter_image.m * dilation,) * 2 for dilation in rhs_dilation)
+            else:
+                padding_literal = padding
 
-        img_expanded, filter_expanded = GeometricImage.pre_tensor_product_expand(torus_expand_img, filter_image)
+        img_expanded, filter_expanded = GeometricImage.pre_tensor_product_expand(image, filter_image)
         img_expanded = img_expanded.astype(dtype)
         filter_expanded = filter_expanded.astype(dtype)
 
@@ -635,7 +659,7 @@ class GeometricImage:
         # convert the image to NHWC (or NHWDC), treating all the pixel values as channels
         img_formatted = self.__class__.data_to_NHWC_format(
             img_expanded,
-            torus_expand_img.image_shape(),
+            image.image_shape(),
             channel_length,
         )
 
@@ -645,13 +669,17 @@ class GeometricImage:
         convolved_array = jax.lax.conv_general_dilated(
             img_formatted, #lhs
             filter_formatted, #rhs
-            (1,) * self.D, #window strides
-            padding_mode,
+            stride,
+            padding_literal,
+            lhs_dilation=lhs_dilation,
             rhs_dilation=rhs_dilation,
             dimension_numbers=(('NHWC','HWIO','NHWC') if self.D == 2 else ('NHWDC','HWDIO','NHWDC')),
             feature_group_count=channel_length, #allows us to have separate filters for separate channels
-        ).reshape(self.image_shape() + (self.D,)*output_k) #reshape the pixel to the correct tensor shape
-        return self.__class__(convolved_array, self.parity + filter_image.parity, self.D, self.is_torus)
+        )
+        # if we need to get rid of the batch index at the beginning becuase its not a BatchGeometricImage
+        start_idx = 0 if len(convolved_array.shape) == len(self.image_shape())+1 else 1
+        out_data = convolved_array.reshape(convolved_array.shape[start_idx:-1] + (self.D,)*output_k)
+        return self.__class__(out_data, self.parity + filter_image.parity, self.D, self.is_torus)
 
     def get_torus_expanded(self, filter_image, dilation):
         """
@@ -659,16 +687,62 @@ class GeometricImage:
         just doing convolutions on the expanded image and will get the same result. Return a new GeometricImage
         args:
             filter_image (GeometricFilter): filter, how much is expanded depends on filter_image.m
+            dilation (int): dilation to apply to each filter dimension D
         """
         padding = filter_image.m * dilation
         new_N = self.N + 2 * padding
         indices = jnp.array(list(it.product(range(new_N), repeat=self.D)), dtype=int) - padding
         return self.__class__(
-            self[self.hash(indices)].reshape((new_N,) * self.D + self.pixel_shape()),
+            self[self.hash(indices)].reshape(self.image_shape(plus_N=(2 * padding)) + self.pixel_shape()),
             self.parity,
             self.D,
             self.is_torus,
         )
+
+    @partial(jit, static_argnums=1)
+    def max_pool(self, patch_len):
+        """
+        Perform a max pooling operation where the length of the side of each patch is patch_len. Max is determined by
+        the norm of the pixel. Note that for scalars, this will be the absolute value of the pixel.
+        args:
+            patch_len (int): the side length of the patches, must evenly divide self.N
+        """
+        assert (self.N % patch_len) == 0
+        plus_N = -1*(self.N - int(self.N / patch_len))
+
+        idxs = jnp.array(list(it.product(range(patch_len), repeat=self.D)))
+        max_idxs = []
+        for base in it.product(range(0, self.N, patch_len), repeat=self.D):
+            block_idxs = jnp.array(base) + idxs
+            max_hash_idx = jnp.argmax(self.norm()[self.hash(block_idxs)])
+            max_idxs.append(block_idxs[max_hash_idx])
+
+        max_data = self[self.hash(jnp.array(max_idxs))].reshape(self.image_shape(plus_N) + self.pixel_shape())
+        return self.__class__(max_data, self.parity, self.D, self.is_torus)
+
+    @partial(jit, static_argnums=1)
+    def average_pool(self, patch_len):
+        """
+        Perform a average pooling operation where the length of the side of each patch is patch_len. This is 
+        equivalent to doing a convolution where each element of the filter is 1 over the number of pixels in the 
+        filter, the stride length is patch_len, and the padding is 'VALID'.
+        args:
+            patch_len (int): the side length of the patches, must evenly divide self.N
+        """
+        assert (self.N % patch_len) == 0
+
+        avg_filter =GeometricImage((1/(patch_len ** self.D))* jnp.ones((patch_len,)*self.D), 0, self.D)
+        return self.convolve_with(avg_filter, stride=(patch_len,) * self.D, padding='VALID')
+
+    @partial(jit, static_argnums=1)
+    def unpool(self, patch_len):
+        """
+        Each pixel turns into a (patch_len,)*self.D patch of that pixel
+        args:
+            patch_len (int): side length of the patch of our unpooled images
+        """
+        grow_filter = GeometricImage(jnp.ones((patch_len,)*self.D), 0, self.D)
+        return self.convolve_with(grow_filter, padding=((patch_len-1,)*2,)*self.D, lhs_dilation=(patch_len,)*self.D)
 
     def times_scalar(self, scalar):
         """
@@ -678,22 +752,23 @@ class GeometricImage:
         """
         return self * scalar
 
+    @jit
     def norm(self):
         """
         Calculate the norm pixel-wise
         """
-        if self.k == 0:
-            return jnp.abs(self.data)
+        # it is possible that the parity of the new image is always 0
+        vmap_norm = jnp.linalg.norm
+        for _ in range(len(self.image_shape())): #not sure if there is a jax way to avoid unrolling this loop
+            vmap_norm = vmap(vmap_norm)
 
-        image_size = int(np.multiply.reduce(self.image_shape()))
-        vectorized_pixels = self.data.reshape(((image_size,) + self.pixel_shape()))
-        return jnp.array([jnp.linalg.norm(x, ord=None) for x in vectorized_pixels]).reshape(self.image_shape())
+        return self.__class__(vmap_norm(self.data), self.parity, self.D, self.is_torus)
 
     def normalize(self):
         """
         Normalize so that the max norm of each pixel is 1, and all other tensors are scaled appropriately
         """
-        max_norm = jnp.max(self.norm())
+        max_norm = jnp.max(self.norm().data)
         if max_norm > TINY:
             return self.times_scalar(1. / max_norm)
         else:
@@ -862,7 +937,7 @@ class GeometricFilter(GeometricImage):
         """
         Gives an idea of size for a filter, sparser filters are smaller while less sparse filters are larger
         """
-        norms = self.norm()
+        norms = self.norm().data
         numerator = 0.
         for key in self.key_array():
             numerator += jnp.linalg.norm(key * norms[tuple(key)], ord=2)
@@ -974,12 +1049,31 @@ class BatchGeometricImage(GeometricImage):
         data = jnp.stack([images[idx].data for idx in indices])
         return cls(data, images[0].parity, images[0].D, images[0].is_torus)
 
-    def image_shape(self):
+    def to_images(self):
+        """
+        Convert a batch image to a list of the individual images. Generally, doing this, then applying an operation,
+        then converting back to the batch will be less efficient than operating on the batch.
+        """
+        return [GeometricImage(image_data, self.parity, self.D, self.is_torus) for image_data in self.data]
+
+    def image_shape(self, plus_N=0):
         """
         Return the shape of the data block that is not the ktensor shape, but what comes before that. For regular
         GeometricImages, this is shape of the literal image. For BatchGeometricImage it prepends the batch size L.
+        args:
+            plus_N (int): number to add to self.N, used when shape will be growing/shrinking.
         """
-        return (self.L,) + (self.N,) * self.D
+        return (self.L,) + super(BatchGeometricImage, self).image_shape(plus_N)
+
+    def __getitem__(self, key):
+        """
+        Accessor for data values. For the BatchGeometricImage, we prepend ':' to the key automatically so that you
+        are selecting starting with the pixels on ALL images in the batch. If you want to select without this prepend,
+        do self.data[key] instead of self[key].
+        args:
+            key (index): JAX/numpy indexer, i.e. "0", "0,1,3", "4:, 2:3, 0" etc.
+        """
+        return self.data[(slice(None),)+key]
 
     def __str__(self):
         return "<{} object with L={} images in D={} with N={}, k={}, parity={}, and is_torus={}>".format(
@@ -1014,24 +1108,15 @@ class BatchGeometricImage(GeometricImage):
         """
         return image_data.reshape(image_shape + (channel_length,))
 
-    def get_torus_expanded(self, filter_image):
+    def max_pool(self, patch_len):
         """
-        For a particular filter, expand the image so that we no longer have to do convolutions on the torus, we are
-        just doing convolutions on the expanded image and will get the same result. Return a new GeometricImage
+        Perform a max pooling operation where the length of the side of each patch is patch_len. Max is determined by
+        the norm of the pixel. Note that for scalars, this will be the absolute value of the pixel.
         args:
-            filter_image (GeometricFilter): filter, how much is expanded depends on filter_image.m
+            patch_len (int): the side length of the patches, must evenly divide self.N
         """
-        new_N = self.N + 2 * filter_image.m
-        indices = jnp.array(list(it.product(range(new_N), repeat=self.D)), dtype=int) - filter_image.m
-        flipped_data = jnp.moveaxis(self.data, 0, -1) #flip batch axis to the end
-        indexed_data = jnp.moveaxis(flipped_data[self.hash(indices)], -1, 0) #flip batch axis back to the front
-
-        return self.__class__(
-            indexed_data.reshape((self.L,) + (new_N,) * self.D + self.pixel_shape()),
-            self.parity,
-            self.D,
-            self.is_torus,
-        )
+        # there has to be a better way of doing this
+        return BatchGeometricImage.from_images([image.max_pool(patch_len) for image in self.to_images()]) 
 
     # TODO!!
     def normalize(self):

--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -53,7 +53,7 @@ def conv_layer(params, param_idx, conv_filters, input_layer, target_x=None, bias
                         prods_group.append(bias_img)
 
                     group_sum = geom.linear_combination(prods_group, params[param_idx:(param_idx + len(prods_group))])
-                    out_layer.append(group_sum.convolve_with(conv_filter, dilation=dilation))
+                    out_layer.append(group_sum.convolve_with(conv_filter, rhs_dilation=(dilation,)*group_sum.D))
                     param_idx += len(prods_group)
 
     return out_layer, param_idx
@@ -190,6 +190,15 @@ def cascading_contractions(params, param_idx, x, input_layer):
             param_idx += len(images)
 
     return images_by_k[x.k], param_idx
+
+def max_pool_layer(input_layer, patch_len):
+    return [image.max_pool(patch_len) for image in input_layer]
+
+def average_pool_layer(input_layer, patch_len):
+    return [image.average_pool(patch_len) for image in input_layer]
+
+def unpool_layer(input_layer, patch_len):
+    return [image.unpool(patch_len) for image in input_layer]
 
 ## Params
 

--- a/tests/test_batch_geometric_image.py
+++ b/tests/test_batch_geometric_image.py
@@ -100,3 +100,66 @@ class TestBatchGeometricImage:
 
         with pytest.raises(AssertionError): #L not equal
             image1 * image3
+
+    def testMaxPool(self):
+        image1 = geom.GeometricImage(
+            jnp.array([
+                [4,1,0,1], 
+                [0,0,-3,2], 
+                [1,0,1,0],
+                [1,0,2,1],
+            ], dtype=float),
+            0,
+            2,
+        )
+        image2 = geom.GeometricImage(jnp.arange(4 ** 2).reshape((4,4)), 0, 2)
+
+        batch_image = geom.BatchGeometricImage.from_images([image1, image2])
+
+        batch_image_pool2 = batch_image.max_pool(2)
+        assert batch_image_pool2.N == 2
+        assert batch_image_pool2.parity == 0
+        assert batch_image_pool2.D == 2
+        assert batch_image_pool2.k == 0
+        assert batch_image_pool2.is_torus == True
+        assert batch_image_pool2.L == 2
+        assert batch_image_pool2 == geom.BatchGeometricImage(
+            jnp.array([
+                [[4,-3],[1,2]],
+                [[5,7],[13,15]],
+            ]),
+            0,
+            2,
+        )
+
+    def testAveragePool(self):
+        image1 = geom.GeometricImage(
+            jnp.array([
+                [4,1,0,1], 
+                [0,0,-3,2], 
+                [1,0,1,0],
+                [1,0,2,1],
+            ], dtype=float),
+            0,
+            2,
+        )
+        image2 = geom.GeometricImage(jnp.arange(4 ** 2).reshape((4,4)), 0, 2)
+
+        batch_image = geom.BatchGeometricImage.from_images([image1, image2])
+
+        batch_image_pool2 = batch_image.average_pool(2)
+        assert batch_image_pool2.N == 2
+        assert batch_image_pool2.parity == 0
+        assert batch_image_pool2.D == 2
+        assert batch_image_pool2.k == 0
+        assert batch_image_pool2.is_torus == True
+        assert batch_image_pool2.L == 2
+        assert batch_image_pool2 == geom.BatchGeometricImage(
+            jnp.array([
+                [[1.25,0],[0.5,1]],
+                [[2.5,4.5],[10.5,12.5]],
+            ]),
+            0,
+            2,
+        )
+        


### PR DESCRIPTION
## Changes
- swap image_shape to take an optional `plus_N` where it returns the image shape if we added N to each dimension
- generalize `convolve_with` so that it handles stride, general padding, lhs dilation, and rhs dilation, with appropriate defaults for each.
- write max_pool, average_pool, and unpool operations, along with associated ml layers
- rewrite norm using vmaps and reduce. It also returns an image now instead of just the data array
- fix torus_expand so that we don't need a separate function for BatchGeometricImage
- write accessor for BatchGeometricImage that prepends the first index so that you are getting the pixels across the batch

## Testing
- unit tests, other small testing

## Doc Changes
- none

