### PR TITLE
add bias, other improvements to benchmark models

### DIFF
--- a/scripts/phase2vec_benchmark.py
+++ b/scripts/phase2vec_benchmark.py
@@ -380,8 +380,6 @@ def handleArgs(argv):
 epochs, lr, batch_size, seed, save_folder, load_folder, verbose = handleArgs(sys.argv)
 
 D = 2
-batch_norm = True
-dropout = True
 
 key = random.PRNGKey(time.time_ns() if (seed is None) else seed)
 

--- a/scripts/phase2vec_benchmark.py
+++ b/scripts/phase2vec_benchmark.py
@@ -6,6 +6,7 @@ from functools import partial
 import argparse
 import time
 from scipy.special import binom
+import math
 
 import jax.numpy as jnp
 import jax.random as random
@@ -119,20 +120,35 @@ def sindy_library(X, poly_order, include_sine=False, include_exp=False):
     library_terms.insert(0,'1')
     return library, library_terms
 
-def fully_connected_layer(params, param_idx, x, width):
+def fully_connected_layer(params, param_idx, x, width, bias=True):
     weights_shape = (width, len(x))
     weights_size = width * len(x)
     W = params[param_idx:(param_idx + weights_size)].reshape(weights_shape)
     param_idx += weights_size
-    return W @ x, param_idx
+    out_vec = W @ x
 
-@partial(jit, static_argnums=1)
-def batch_norm_1d(x, eps=1e-05):
-    # x is shape (batch, width)
-    return (x - jnp.mean(x, axis=0))/jnp.sqrt(jnp.var(x, axis=0) + eps)
+    if bias:
+        b = params[param_idx:(param_idx + width)]
+        param_idx += width
+        out_vec = out_vec + b
+
+    return out_vec, param_idx
 
 @partial(jit, static_argnums=[1,3])
-def dropout(x, p, key, train):
+def batch_norm_1d(params, param_idx, x, eps=1e-05):
+    # x is shape (batch, width)
+    width = x.shape[1]
+    params_mult = params[param_idx:(param_idx+width)]
+    param_idx += width
+    params_add = params[param_idx:(param_idx+width)]
+    param_idx += width
+
+    layer_vec = (x - jnp.mean(x, axis=0))/jnp.sqrt(jnp.var(x, axis=0) + eps)
+    layer_vec = vmap(lambda x: x * params_mult)(layer_vec)
+    return vmap(lambda x: x + params_add)(layer_vec), param_idx
+
+@partial(jit, static_argnums=[1,3])
+def dropout_layer(x, p, key, train):
     """
     Dropout layer. If training, randomly set values of the layer to 0 at a rate of p
     args:
@@ -144,9 +160,9 @@ def dropout(x, p, key, train):
     if not train:
         return x 
     
-    return x * (random.uniform(key, shape=x.shape) > p).astype(x.dtype)
+    return (x * (random.uniform(key, shape=x.shape) > p).astype(x.dtype))*(1/(1-p))
 
-def net(params, layer, conv_filters, ode_basis, key, train=True, return_params=False):
+def net(params, layer, key, train, conv_filters, ode_basis, batch_norm=True, dropout=True, return_params=False):
     # batch norm, dropout seem to make the network widely worse, not sure why.
     embedding_d = 100
     num_coeffs = ode_basis.shape[1]
@@ -164,7 +180,7 @@ def net(params, layer, conv_filters, ode_basis, key, train=True, return_params=F
         stride=(2,)*layer.D, 
         padding='VALID',
     )
-    # layer = ml.batch_norm(layer)
+    # layer, param_idx = ml.batch_norm(params, int(param_idx), layer)
     layer = ml.batch_relu_layer(layer)
 
     layer, param_idx = ml.batch_conv_layer(
@@ -176,7 +192,7 @@ def net(params, layer, conv_filters, ode_basis, key, train=True, return_params=F
         stride=(2,)*layer.D, 
         padding='VALID',
     )
-    # layer = ml.batch_norm(layer)
+    # layer, param_idx = ml.batch_norm(params, int(param_idx), layer)
     layer = ml.batch_relu_layer(layer)
 
     layer, param_idx = ml.batch_conv_layer(
@@ -188,7 +204,7 @@ def net(params, layer, conv_filters, ode_basis, key, train=True, return_params=F
         stride=(2,)*layer.D, 
         padding='VALID', 
     )
-    # layer = ml.batch_norm(layer)
+    # layer, param_idx = ml.batch_norm(params, int(param_idx), layer)
     layer = ml.batch_relu_layer(layer)
 
     # Embed the ODE in a d=100 vector
@@ -200,16 +216,20 @@ def net(params, layer, conv_filters, ode_basis, key, train=True, return_params=F
 
     # Pass the embedded ode through a 2 layer MLP to get the coefficients of poly ode
     layer_vec, param_idx = batch_fully_connected(params, int(param_idx), embedded_ode, 128)
-    # layer_vec = batch_norm_1d(layer_vec)
-    # layer_vec = jax.nn.relu(layer_vec)
-    # key, subkey = random.split(key)
-    # layer_vec = dropout(layer_vec, 0.1, subkey ,train)
+    if batch_norm:
+        layer_vec, param_idx = batch_norm_1d(params, int(param_idx), layer_vec)
+    layer_vec = jax.nn.relu(layer_vec)
+    if dropout:
+        key, subkey = random.split(key)
+        layer_vec = dropout_layer(layer_vec, 0.1, subkey ,train)
 
     layer_vec, param_idx = batch_fully_connected(params, int(param_idx), layer_vec, 128)
-    # layer_vec = batch_norm_1d(layer_vec)
-    # layer_vec = jax.nn.relu(layer_vec)
-    # key, subkey = random.split(key)
-    # layer_vec = dropout(layer_vec, 0.1, subkey, train)
+    if batch_norm:
+        layer_vec, param_idx = batch_norm_1d(params, int(param_idx), layer_vec)
+    layer_vec = jax.nn.relu(layer_vec)
+    if dropout:
+        key, subkey = random.split(key)
+        layer_vec = dropout_layer(layer_vec, 0.1, subkey, train)
 
     coeffs, param_idx = batch_fully_connected(params, int(param_idx), layer_vec, num_coeffs * layer.D)
     coeffs = coeffs.reshape((layer.L, num_coeffs, layer.D))
@@ -219,29 +239,31 @@ def net(params, layer, conv_filters, ode_basis, key, train=True, return_params=F
     recon_x = vmap_mul(coeffs).reshape((layer.L,) + (img_N,)*layer.D + (layer.D,))
     return (recon_x, coeffs, param_idx) if return_params else (recon_x, coeffs)
 
-def phase2vec_loss(recon_x, layer_y, coeffs, eps=1e-5, beta=1e-3):
+def phase2vec_loss(recon_x, y, coeffs, eps=1e-5, beta=1e-3, reduce=True):
     """
     Loss used in the phase2vec paper, combines a pointwise normalized l2 loss with a sparsity l1 loss
+    args:
+        recon_x (jnp.array): image block of (batch, N, N, D)
+        y (jnp.array): image_block of (batch, N, N, D)
     """
-    y = layer_y[1][:,0,...]
-    m_gt = jnp.linalg.norm(y, axis=layer_y.D+1) #this maybe only works when k=1, its a vector field
-    den = jnp.expand_dims(m_gt + eps, axis=layer_y.D+1) #ensure division is broadcast correctly
-    # den shape will be (batch, N, N, 1)
-    # recon shape will be (batch, N, N, D), since k=1
+    '''Euclidean distance between two arrays with spatial dimensions. Normalizes pointwise across the spatial dimension by the norm of the second argument'''
+    m_gt = jnp.expand_dims(jnp.linalg.norm(y, axis=3), axis=3)
+    den = m_gt + eps 
 
-    #should be sum rather than mean?
-    batch_loss = jnp.sqrt(vmap(jnp.mean)(((recon_x - y)**2) / den)) #normalize pointwise by gt norm
-    normalized_loss = jnp.mean(batch_loss) #average the loss over the batch
+    # normalize pointwise by the gt norm
+    if reduce:
+        recon_loss = jnp.mean(jnp.sqrt(vmap(jnp.mean)(((recon_x - y)**2) / den)))
+    else:
+        recon_loss = jnp.mean(jnp.sqrt(((recon_x - y)**2) / den))
 
-    sparsity_loss = jnp.mean(jnp.abs(coeffs))
-    return normalized_loss + beta * sparsity_loss
+    return recon_loss if (beta is None) else recon_loss + beta * jnp.mean(jnp.abs(coeffs))
 
 partial(jit, static_argnums=[4,5,6])
-def map_and_loss(params, layer_x, layer_y, key, train, conv_filters, ode_basis, eps=1e-5, beta=1e-3):
-    recon, coeffs = net(params, layer_x, conv_filters, ode_basis, key, train=train)
-    return phase2vec_loss(recon, layer_y, coeffs, eps, beta)
+def map_and_loss(params, layer_x, layer_y, key, train, conv_filters, ode_basis, batch_norm, dropout, eps=1e-5, beta=1e-3):
+    recon, coeffs = net(params, layer_x, key, train, conv_filters, ode_basis, batch_norm, dropout)
+    return phase2vec_loss(recon, layer_y[1][:,0,...], coeffs, eps, beta)
 
-def baseline_net(params, layer, ode_basis, key, train=True, return_params=False):
+def baseline_net(params, layer, key, train, ode_basis, batch_norm, dropout, return_params=False):
     embedding_d = 100
     num_coeffs = ode_basis.shape[1]
     img_N = layer.N
@@ -258,10 +280,12 @@ def baseline_net(params, layer, ode_basis, key, train=True, return_params=False)
         layer, 
         { 'type': 'free', 'M': 3, 'filter_k_set': (0,) },
         depth=128,
+        bias=True,
         stride=(2,)*layer.D,
         padding='VALID',
     )
-    # layer = ml.batch_norm(layer)
+    if batch_norm:
+        layer, param_idx = ml.batch_norm(params, int(param_idx), layer)
     layer = ml.batch_relu_layer(layer)
 
     layer, param_idx = ml.batch_conv_layer(
@@ -270,10 +294,12 @@ def baseline_net(params, layer, ode_basis, key, train=True, return_params=False)
         layer, 
         { 'type': 'free', 'M': 3, 'filter_k_set': (0,) },
         depth=128,
+        bias=True,
         stride=(2,)*layer.D, 
         padding='VALID', 
     )
-    # layer = ml.batch_norm(layer)
+    if batch_norm:
+        layer, param_idx = ml.batch_norm(params, int(param_idx), layer)
     layer = ml.batch_relu_layer(layer)
 
     layer, param_idx = ml.batch_conv_layer(
@@ -282,31 +308,38 @@ def baseline_net(params, layer, ode_basis, key, train=True, return_params=False)
         layer, 
         { 'type': 'free', 'M': 3, 'filter_k_set': (0,) },
         depth=128,
+        bias=True,
         stride=(2,)*layer.D, 
         padding='VALID', 
     )
-    # layer = ml.batch_norm(layer)
+    if batch_norm:
+        layer, param_idx = ml.batch_norm(params, int(param_idx), layer)
     layer = ml.batch_relu_layer(layer)
     
     # Embed the ODE in a d=100 vector
-    embedded_ode = jnp.zeros(embedding_d)
-    for image in layer.values():
-        vectorized_image = image.reshape(layer.L,-1)
-        layer_out, param_idx = batch_fully_connected(params, int(param_idx), vectorized_image, embedding_d)
-        embedded_ode += layer_out
+    embedded_ode, param_idx = batch_fully_connected(
+        params, 
+        int(param_idx), 
+        layer[0].reshape(layer.L,-1), 
+        embedding_d,
+    )
 
     # Pass the embedded ode through a 2 layer MLP to get the coefficients of poly ode
     layer_vec, param_idx = batch_fully_connected(params, int(param_idx), embedded_ode, 128)
-    # layer_vec = batch_norm_1d(layer_vec)
-    # layer_vec = jax.nn.relu(layer_vec)
-    # key, subkey = random.split(key)
-    # layer_vec = dropout(layer_vec, 0.1, subkey, train)
+    if batch_norm:
+        layer_vec, param_idx = batch_norm_1d(params, int(param_idx), layer_vec)
+    layer_vec = jax.nn.relu(layer_vec)
+    if dropout:
+        key, subkey = random.split(key)
+        layer_vec = dropout_layer(layer_vec, 0.1, subkey, train)
 
     layer_vec, param_idx = batch_fully_connected(params, int(param_idx), layer_vec, 128)
-    # layer_vec = batch_norm_1d(layer_vec)
-    # layer_vec = jax.nn.relu(layer_vec)
-    # key, subkey = random.split(key)
-    # layer_vec = dropout(layer_vec, 0.1, subkey, train)
+    if batch_norm:
+        layer_vec, param_idx = batch_norm_1d(params, int(param_idx), layer_vec)
+    layer_vec = jax.nn.relu(layer_vec)
+    if dropout:
+        key, subkey = random.split(key)
+        layer_vec = dropout_layer(layer_vec, 0.1, subkey, train)
 
     coeffs, param_idx = batch_fully_connected(params, int(param_idx), layer_vec, num_coeffs * layer.D)
     coeffs = coeffs.reshape((layer.L, num_coeffs, layer.D))
@@ -316,19 +349,19 @@ def baseline_net(params, layer, ode_basis, key, train=True, return_params=False)
     recon_x = vmap_mul(coeffs).reshape((layer.L,) + (img_N,)*layer.D + (layer.D,))
     return (recon_x, coeffs, param_idx) if return_params else (recon_x, coeffs)
 
-partial(jit, static_argnums=[4,5,6])
-def baseline_map_and_loss(params, layer_x, layer_y, key, train, ode_basis, eps=1e-5, beta=1e-3):
-    recon, coeffs = baseline_net(params, layer_x, ode_basis, key, train=train)
-    return phase2vec_loss(recon, layer_y, coeffs, eps, beta)
+# partial(jit, static_argnums=[4,5,6])
+def baseline_map_and_loss(params, layer_x, layer_y, key, train, ode_basis, batch_norm, dropout, eps=1e-5, beta=1e-3):
+    recon, coeffs = baseline_net(params, layer_x, key, train, ode_basis, batch_norm, dropout)
+    return phase2vec_loss(recon, layer_y[1][:,0,...], coeffs, eps, beta)
 
 def handleArgs(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument('-e', '--epochs', help='number of epochs', type=float, default=200)
-    parser.add_argument('-lr', help='learning rate', type=float, default=0.001)
-    parser.add_argument('-batch', help='batch size', type=int, default=10)
+    parser.add_argument('-lr', help='learning rate', type=float, default=1e-4)
+    parser.add_argument('-batch', help='batch size', type=int, default=64)
     parser.add_argument('-seed', help='the random number seed', type=int, default=None)
-    parser.add_argument('-s', '--save', help='file name to save the results', type=str, default=None)
-    parser.add_argument('-l', '--load', help='file name to load results from', type=str, default=None)
+    parser.add_argument('-s', '--save', help='folder name to save the results', type=str, default=None)
+    parser.add_argument('-l', '--load', help='folder name to load results from', type=str, default=None)
     parser.add_argument('-v', '--verbose', help='levels of print statements during training', type=int, default=1)
 
     args = parser.parse_args()
@@ -344,16 +377,19 @@ def handleArgs(argv):
     )
 
 # Main
-epochs, lr, batch_size, seed, save_file, load_file, verbose = handleArgs(sys.argv)
+epochs, lr, batch_size, seed, save_folder, load_folder, verbose = handleArgs(sys.argv)
 
 D = 2
+batch_norm = True
+dropout = True
 
-key = random.PRNGKey(seed if seed else time.time_ns())
+key = random.PRNGKey(time.time_ns() if (seed is None) else seed)
 
 # start with basic 3x3 scalar, vector, and 2nd order tensor images
 operators = geom.make_all_operators(D)
 conv_filters = geom.get_invariant_filters(Ms=[3], ks=[0,1], parities=[0], D=D, operators=operators)
 
+# Get Training data
 train_data_path = '../phase2vec/output/data/polynomial'
 X_train_data, X_val_data, y_train, y_val, p_train, p_val = load_dataset(train_data_path)
 X_train = geom.BatchLayer(
@@ -366,7 +402,18 @@ X_val = geom.BatchLayer(
     D,
     False,
 )
-X_val = X_val.get_subset(jnp.arange(100)) #reduce the size of val set b/c baseline is running out of mem
+
+# Get testing data. We add the validation data set to the test data, as they do in the paper
+test_data_path = '../phase2vec/output/data/classical'
+X_test1, X_test2, y_test1, y_test2, p_test1, p_test2 = load_dataset(test_data_path)
+X_test_data = jnp.concatenate([X_test1, X_test2, X_val_data])
+y_test = jnp.concatenate([y_test1, y_test2, 16 * np.ones_like(y_val)])
+p_test = jnp.concatenate([p_test1, p_test2, p_val])
+X_test = geom.BatchLayer(
+    { 1: jnp.expand_dims(X_test_data.transpose(0,2,3,1), axis=1) },
+    D,
+    False,
+)
 
 # generate function library
 spatial_coords = [jnp.linspace(mn, mx, X_train.N) for (mn, mx) in zip([-1.,-1.], [1.,1.])]
@@ -374,61 +421,130 @@ mesh = jnp.meshgrid(*spatial_coords)
 L = jnp.concatenate([ms[..., None] for ms in mesh], axis=-1)
 ode_basis, _ = sindy_library(L.reshape(X_train.N**D,D), 3)
 
-#its only a single point, but net expects a BatchLayer so that is what we do.
-one_point = X_train.get_subset(jnp.array([0]))
-
-huge_params = jnp.ones(100000000) #hundred million
-_, _, num_params_model = net(
-    huge_params,
-    one_point,
-    conv_filters,
-    ode_basis,
-    key,
-    train=True,
-    return_params=True,
-)
-print(f'Model Params: {num_params_model}')
-
-_, _, num_params_baseline = baseline_net(
-    huge_params,
-    one_point,
-    ode_basis,
-    key,
-    train=True,
-    return_params=True,
-)
-print(f'Baseline Params {num_params_baseline}')
-
+# Define the models that we are benchmarking
 models = [
     (
-        'GI-Net',
-        partial(map_and_loss, conv_filters=conv_filters, ode_basis=ode_basis),
-        num_params_model,
+        'gi_net',
+        partial(map_and_loss, conv_filters=conv_filters, ode_basis=ode_basis, batch_norm=True, dropout=True),
+        partial(net, conv_filters=conv_filters, ode_basis=ode_basis, batch_norm=True, dropout=True),
     ),
     (
-        'Baseline',
-        partial(baseline_map_and_loss, ode_basis=ode_basis),
-        num_params_baseline,
+        'gi_net_no_batch_norm',
+        partial(map_and_loss, conv_filters=conv_filters, ode_basis=ode_basis, batch_norm=False, dropout=False),
+        partial(net, conv_filters=conv_filters, ode_basis=ode_basis, batch_norm=False, dropout=False),
+    ),
+    (
+        'baseline',
+        partial(baseline_map_and_loss, ode_basis=ode_basis, batch_norm=True, dropout=True),
+        partial(baseline_net, ode_basis=ode_basis, batch_norm=True, dropout=True),
+    ),
+    (
+        'baseline_no_batch_norm',
+        partial(baseline_map_and_loss, ode_basis=ode_basis, batch_norm=False, dropout=False),
+        partial(baseline_net, ode_basis=ode_basis, batch_norm=False, dropout=False),
     ),
 ]
 
-for model_name, model, num_params in models:
-    print(f'Model {model_name}')
+# For each model, calculate the size of the parameters and add it to the tuple.
+huge_params = jnp.ones(100000000) #hundred million
+one_point = X_train.get_subset(jnp.array([0]))
+models_init = []
+for model_name, model_map_and_loss, model in models:
+    num_params = model(huge_params, one_point, key, train=True, return_params=True)[2]
+    print(f'{model_name}: {num_params} params')
+    models_init.append((model_name, model_map_and_loss, model, num_params))
 
-    key, subkey = random.split(key)
-    params = 0.1*random.normal(subkey, shape=(num_params,))
+labels = ['saddle_node 0',
+    'saddle_node 1',
+    'pitchfork 0',
+    'pitchfork 1',
+    'transcritical 0',
+    'transcritical 1',
+    'selkov 0',
+    'selkov 1',
+    'homoclinic 0',
+    'homoclinic 1',
+    'vanderpol 0',
+    'simple_oscillator 0',
+    'simple_oscillator 1',
+    'fitzhugh_nagumo 0',
+    'fitzhugh_nagumo 1',
+    'lotka_volterra 0',
+    'polynomial',
+]
 
-    key, subkey = random.split(key)
-    params, _, _ = ml.train(
-        X_train,
-        X_train, #reconstruction, so we want to get back to the input
-        model,
-        params,
-        subkey,
-        ml.EpochStop(epochs, verbose=verbose),
-        batch_size=batch_size,
-        optimizer=optax.adam(lr),
-        validation_X=X_val,
-        validation_Y=X_val, # reconstruction, reuse X_val as the Y
-        save_params=save_file,
-    )
+for model_name, model, eval_net, num_params in models_init:
+    print(f'Model: {model_name}')
+
+    if load_folder:
+        params = jnp.load(f'{load_folder}/{model_name}_s{seed}.npy')
+    else:
+        key, subkey = random.split(key)
+        # might want to try to do kaiming initialization here
+        # params = random.uniform(subkey, shape=(num_params,), minval=-0.1, maxval=0.1)
+        params = 0.1*random.normal(subkey, shape=(num_params,))
+
+        key, subkey = random.split(key)
+        params, _, _ = ml.train(
+            X_train,
+            X_train, #reconstruction, so we want to get back to the input
+            model,
+            params,
+            subkey,
+            ml.EpochStop(epochs, verbose=verbose),
+            batch_size=batch_size,
+            optimizer=optax.adam(lr),
+            validation_X=X_val,
+            validation_Y=X_val, # reconstruction, reuse X_val as the Y
+        )
+
+        if save_folder:
+            jnp.save(f'{save_folder}/{model_name}_s{seed}.npy', params)
+
+    par_losses = []
+    recon_losses = []
+    recon_dict = {}
+    coeffs_dict = {}
+    for label in jnp.unique(y_test):
+        class_layer = X_test.get_subset(y_test == label)
+        class_pars = p_test[y_test == label]
+        class_data = class_layer[1][:,0,...]
+
+        full_recon = None
+        full_coeffs = None
+        for i in range(math.ceil(len(class_data) / batch_size)): #split into batches if its too big
+            batch_layer = class_layer.get_subset(jnp.arange(
+                batch_size*i, 
+                min(batch_size*(i+1), len(class_data)),
+            ))
+
+            key, subkey = random.split(key)
+            recon, coeffs = eval_net(
+                params, 
+                batch_layer, 
+                key=subkey, 
+                train=False,
+            )
+
+            if full_recon is None:
+                full_recon = recon
+                full_coeffs = coeffs
+            else:
+                full_recon = jnp.concatenate([full_recon, recon])
+                full_coeffs = jnp.concatenate([full_coeffs, coeffs])
+
+        recon_dict[int(label)] = np.array(full_recon)
+        coeffs_dict[int(label)] = np.array(full_coeffs)
+
+        assert full_coeffs.shape == class_pars.shape
+        assert full_recon.shape == class_data.shape
+        par_loss = ml.mse_loss(full_coeffs, class_pars)
+        recon_loss = phase2vec_loss(full_recon, class_data, full_coeffs, beta=None, reduce=False)
+
+        print(f'{labels[label]}, par: {par_loss:0.5f} --- recon: {recon_loss:0.5f}')
+
+        par_losses.append(par_loss)
+        recon_losses.append(recon_loss)
+
+    print('Mean par loss: ', jnp.mean(jnp.stack(par_losses)))
+    print('Mean recon loss: ', jnp.mean(jnp.stack(recon_losses)))

--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -552,13 +552,13 @@ def rmse_loss(x, y):
         x (jnp.array): the input image
         y (jnp.array): the associated output for x that we are comparing against
     """
-    return jnp.sqrt(jnp.mean((x - y) ** 2))
+    return jnp.sqrt(mse_loss(x, y))
 
 def mse_loss(x, y):
     return jnp.mean((x - y) ** 2)
 
 def l2_loss(x, y):
-    return jnp.sqrt(jnp.sum((x - y) ** 2))
+    return jnp.sqrt(l2_squared_loss(x, y))
 
 def l2_squared_loss(x, y):
     return jnp.sum((x - y) ** 2)


### PR DESCRIPTION
## Changes
- add bias to fully connected layer
- add parameters to batch norm layer, in line with https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html
- scale dropout layer by 1/(1-p)
- change phase2vec_loss so that it exactly matches to fp_normalized loss used in the paper
- add bias to baseline cnn convolutions
- add test error to the benchmark
- add some additional losses

## Testing
- ran benchmark script

## Doc Changes
- none