### PR TITLE
allow for different initializations of the parameters in networks

### DIFF
--- a/scripts/gravity_field.py
+++ b/scripts/gravity_field.py
@@ -32,6 +32,15 @@ def plot_results(layer_x, layer_y, axs, titles, conv_filters):
         utils.plot_image(image, ax=ax)
         ax.set_title(title, fontsize=24)
 
+def channel_collapse_init(rand_key, tree):
+    # Use old guassian normal initialization instead of Kaiming
+    out_params = {}
+    for k, params_block in tree.items():
+        rand_key, subkey = random.split(rand_key)
+        out_params[k] = 0.1*random.normal(subkey, params_block.shape)
+
+    return out_params
+
 def batch_net(params, layer, key, train, conv_filters, return_params=False):
     target_k = 1
 
@@ -135,7 +144,12 @@ if load_file:
     params = jnp.load(load_file)
 else:
     key, subkey = random.split(key)
-    params = ml.init_params(partial(batch_net, conv_filters=conv_filters), one_point, subkey)
+    params = ml.init_params(
+        partial(batch_net, conv_filters=conv_filters), 
+        one_point, 
+        subkey,
+        override_initializers={ ml.CHANNEL_COLLAPSE: channel_collapse_init },
+    )
     print('Num params:', ml.count_params(params))
 
     optimizer = optax.adam(optax.exponential_decay(

--- a/scripts/phase2vec_benchmark.py
+++ b/scripts/phase2vec_benchmark.py
@@ -132,7 +132,7 @@ def dense_layer(params, x, width, bias=True, mold_params=False):
     out_vec = this_params[ml.SCALE] @ x
 
     if bias:
-        if mold_params: #unclear whether this should be initialized to 0s
+        if mold_params: 
             this_params[ml.BIAS] = jnp.ones(width)
 
         out_vec = out_vec + this_params[ml.BIAS]

--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -666,12 +666,17 @@ def count_params(params):
 def init_params(net_func, input_layer, rand_key, return_func=False, override_initializers={}):
     """
     Use this function to construct and initialize the tree of params used by the neural network function. The
-    first argument should be a function that takes (params, input_layer, rand_key, train) as arguments. Any other
-    arguments should be provided already, possibly using functools.partial
+    first argument should be a function that takes (params, input_layer, rand_key, train, return_params) as 
+    arguments. Any other arguments should be provided already, possibly using functools.partial. When return_params
+    is true, the function should return params as the last element of a tuple or list.
     args:
         net_func (function): neural network function
         input_layer (geom.Layer): One piece of data to give the initial shape, doesn't have to match batch size
         rand_key (rand key): key used both as input and for the initialization of the params (gets split)
+        return_func (bool): if False, return params, if True return a func that takes a rand_key and returns 
+            the params. Defaults to False.
+        override_initializers (dict): Pass custom initializers with this dictionary. The key is the layer name
+            and the value is a function that takes (rand_key, tree) and returns the tree of initialized params.
     """
     rand_key, subkey = random.split(rand_key)
     params = net_func(defaultdict(lambda: None), input_layer, subkey, True, return_params=True)[-1]
@@ -695,7 +700,7 @@ def init_params(net_func, input_layer, rand_key, return_func=False, override_ini
 
 def recursive_init_params(params, rand_key, initializers):
     """
-    Given a tree of params, initialize all the params according to the initializers.
+    Given a tree of params, initialize all the params according to the initializers. No longer recursive.
     args:
         params (dict tree of jnp.array): properly shaped dict tree
         rand_key (rand key): used for initializing the parameters


### PR DESCRIPTION
## Changes
- Allow for custom initialization of the parameters in layers
- make the default for the majority of layers the Kaiming initialization in the way it is done in pytorch. This in general means that each layer params is initialized ~ Uniform([-1/sqrt(k), 1/sqrt(k)]), where k is the size of the input to that layer.
- for charge and gravity scripts, use old parameterization for reproducibility, N(0, 0.01)
- fix a minor bug in phase2vec gi net model

## Testing
- [x] run vector_example
- [x] run gravity_field
- [x] run gravity_benchmark
- [x] run charge_field
- [x] run charge_benchmark
- [x] run phase2vec
- [x] run turbo3d

## Doc Changes
- None