### PR TITLE
improve efficiency of convolve_contract

### DIFF
--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -452,7 +452,7 @@ def conv_contract(
     this_params[CONV_FIXED] = filter_block_params
 
     # map over filters
-    vmap_convolve = vmap(geom.depth_convolve, in_axes=(None, None, 0, None, None, None, None, None))
+    vmap_convolve = vmap(geom.depth_convolve_contract, in_axes=(None, None, 0, None, None, None, None, None))
 
     layer = input_layer.empty()
     for (k,parity), images_block in input_layer.items():
@@ -462,7 +462,7 @@ def conv_contract(
             
             filter_block = filter_dict[(k,parity)][(target_k, target_parity)]
 
-            convolved_imgs = vmap_convolve(
+            convolve_contracted_imgs = vmap_convolve(
                 input_layer.D, 
                 images_block, 
                 filter_block, 
@@ -473,9 +473,7 @@ def conv_contract(
                 rhs_dilation,
             )
 
-            contract_idxs = tuple((i,i+k) for i in range(k))
-            contracted_imgs = geom.multicontract(convolved_imgs, contract_idxs, idx_shift=input_layer.D+1)
-            layer.append(target_k, target_parity, contracted_imgs)
+            layer.append(target_k, target_parity, convolve_contracted_imgs)
 
     if bias: #is this equivariant?
         out_layer = layer.empty()

--- a/tests/test_functional_geometric_image.py
+++ b/tests/test_functional_geometric_image.py
@@ -1,0 +1,71 @@
+import time
+
+import geometricconvolutions.geometric as geom
+import pytest
+import jax.numpy as jnp
+from jax import random
+
+TINY = 1.e-5
+
+class TestFunctionalGeometricImage:
+    """
+    Class to test the functional versions of the geometric image functions.
+    """
+
+    def testConvolveContract2D(self):
+        """
+        Test that convolve_contract is the same as convolving, then contracting in 2D
+        """
+        N = 3
+        D = 2
+        is_torus = True
+        key = random.PRNGKey(time.time_ns())
+        
+        for img_k in range(4):
+            for filter_k in range(4):
+                key, subkey = random.split(key)
+                image = random.normal(subkey, shape=((N,)*D + (D,)*img_k))
+
+                key, subkey = random.split(key)
+                conv_filter = random.normal(subkey, shape=((N,)*D + (D,)*(img_k+filter_k)))
+
+                contraction_idxs = tuple((i,i+img_k) for i in range(img_k))
+                assert jnp.allclose(
+                    geom.convolve_contract(D, image, conv_filter, is_torus),
+                    geom.multicontract(
+                        geom.convolve(D, image, conv_filter, is_torus), 
+                        contraction_idxs, 
+                        idx_shift=D,
+                    ),
+                    rtol=TINY,
+                    atol=TINY,
+                )
+
+    def testConvolveContract3D(self):
+        """
+        Test that convolve_contract is the same as convolving, then contracting in 3D
+        """
+        N = 3
+        D = 3
+        is_torus = True
+        key = random.PRNGKey(time.time_ns())
+        
+        for img_k in range(3):
+            for filter_k in range(2):
+                key, subkey = random.split(key)
+                image = random.normal(subkey, shape=((N,)*D + (D,)*img_k))
+
+                key, subkey = random.split(key)
+                conv_filter = random.normal(subkey, shape=((N,)*D + (D,)*(img_k+filter_k)))
+
+                contraction_idxs = tuple((i,i+img_k) for i in range(img_k))
+                assert jnp.allclose(
+                    geom.convolve_contract(D, image, conv_filter, is_torus),
+                    geom.multicontract(
+                        geom.convolve(D, image, conv_filter, is_torus), 
+                        contraction_idxs, 
+                        idx_shift=D,
+                    ),
+                    rtol=TINY,
+                    atol=TINY,
+                )


### PR DESCRIPTION
## Changes
- Rather than calculating a full k+k+k' tensor then contracting it, since we know the exact contraction we are going to do beforehand we can only expand the image to k+k' and leave the filter at k+k'. This is akin to doing a matrix multiplication, rather then the tensor product of 2 matrices, then a contraction on the inner axis (and possibly there is some further efficiency there

## Tests
- wrote a unit test to ensure it is the same as convolving, then contracting
- ran the charge_benchmark script

## Doc Changes
- None