### PR TITLE
add unet

### DIFF
--- a/scripts/gravity_field.py
+++ b/scripts/gravity_field.py
@@ -160,12 +160,13 @@ else:
         decay_rate=0.995,
     ))
 
+    key, subkey = random.split(key)
     params, _, _ = ml.train(
         train_X,
         train_Y,
         partial(map_and_loss, conv_filters=conv_filters),
         params,
-        key,
+        subkey,
         ml.ValLoss(patience=20, verbose=verbose),
         batch_size=batch_size,
         optimizer=optimizer,

--- a/scripts/turb2d.py
+++ b/scripts/turb2d.py
@@ -12,8 +12,6 @@ import jax.numpy as jnp
 import jax
 import jax.random as random
 import optax
-from jax.experimental import mesh_utils
-from jax.sharding import PositionalSharding
 
 import geometricconvolutions.geometric as geom
 import geometricconvolutions.ml as ml
@@ -139,16 +137,6 @@ def gi_net(params, layer, key, train, conv_filters, depth, use_odd_parity=False,
         mold_params=return_params,
     )
 
-    if use_odd_parity: # get the residual to line up...
-        layer, params = ml.batch_conv_contract(
-            params, 
-            layer, 
-            conv_filters, 
-            depth, 
-            target_keys, 
-            mold_params=return_params,
-        )
-
     for _ in range(num_blocks):
 
         residual_layer = layer.copy()
@@ -252,19 +240,19 @@ def dil_resnet(params, layer, key, train, return_params=False):
 
     return (layer, params) if return_params else layer
 
-def map_and_loss(params, layer_x, layer_y, key, train, net, aux_data=None):
-    learned_x, batch_stats = net(params, layer_x, key, train, batch_stats=aux_data)
-    # return learned_x[(0,0)][0,0,0,0], None
-
-    # jax.debug.visualize_array_sharding(learned_x[(0,0)][:,:,0,0])
-    # jax.debug.visualize_array_sharding(layer_y[(0,0)][:,:,0,0])
-    # print(batch_stats)
-
-    # return jnp.mean(learned_x[(1,0)] - layer_y[(1,0)]), None
+def map_and_loss(params, layer_x, layer_y, key, train, net, has_aux=False, aux_data=None):
+    if has_aux:
+        learned_x, batch_stats = net(params, layer_x, key, train, batch_stats=aux_data)
+    else:
+        learned_x = net(params, layer_x, key, train)
 
     spatial_size = np.multiply.reduce(geom.parse_shape(layer_x[(1,0)].shape[2:], layer_x.D)[0])
     batch_smse = jax.vmap(lambda x,y: ml.l2_squared_loss(x.to_vector(), y.to_vector())/spatial_size)
-    return jnp.mean(batch_smse(learned_x, layer_y)), batch_stats
+
+    if has_aux:
+        return jnp.mean(batch_smse(learned_x, layer_y)), batch_stats
+    else:
+        return jnp.mean(batch_smse(learned_x, layer_y))
 
 def train_and_eval(
     data, 
@@ -278,7 +266,6 @@ def train_and_eval(
     images_dir, 
     noise_stdev=None,
     has_aux=False,
-    sharding=None,
 ):
     train_X, train_Y, val_X, val_Y, test_X, test_Y = data
 
@@ -292,37 +279,15 @@ def train_and_eval(
 
     steps_per_epoch = int(np.ceil(train_X.L / batch_size))
 
-    # # X_batches, Y_batches = ml.get_batch_layer(train_X, train_Y, batch_size, subkey, sharding)
-    # X_batch = train_X.get_subset(jnp.arange(batch_size)).device_put(sharding, num_gpus).get_subset(jnp.arange(batch_size))
-    # Y_batch = train_Y.get_subset(jnp.arange(batch_size)).device_put(sharding, num_gpus).get_subset(jnp.arange(batch_size))
-    # params = jax.device_put(params, sharding.replicate())
-    # # ml.print_params(params)
-    # # jax.debug.visualize_array_sharding(X_batches[0][(0,0)][:,:,0,0])
-    # # jax.debug.visualize_array_sharding(Y_batches[0][(0,0)][:,:,0,0])
-    # # jax.debug.visualize_array_sharding(params[(0, 'conv')]['free'][(0,0)][(0,0)][:,:,0,0])
-    # # jax.debug.visualize_array_sharding(params)
-    # (loss_val, _), _2 = jax.value_and_grad(map_and_loss, has_aux=has_aux)(
-    #     params, 
-    #     X_batch,
-    #     Y_batch,
-    #     subkey, 
-    #     True, 
-    #     net,
-    # )
-    # print(loss_val)
-    # exit()
-
     key, subkey = random.split(key)
     results = ml.train(
         train_X,
         train_Y,
-        partial(map_and_loss, net=net),
+        partial(map_and_loss, net=net, has_aux=has_aux),
         params,
         subkey,
         stop_condition=ml.EpochStop(epochs, verbose=2),
         batch_size=batch_size,
-        # optimizer=optax.adam(lr),
-        # optimizer=optax.adamw(lr, weight_decay=1e-5),
         optimizer=optax.adamw(
             optax.warmup_cosine_decay_schedule(1e-8, lr, 5*steps_per_epoch, epochs*steps_per_epoch, 1e-7),
             weight_decay=1e-5,
@@ -331,16 +296,13 @@ def train_and_eval(
         validation_Y=val_Y,
         noise_stdev=noise_stdev,
         has_aux=has_aux,
-        sharding=sharding,
     )
 
     if has_aux:
         params, batch_stats, train_loss, val_loss = results
-        trained_net = partial(net, batch_stats=batch_stats)
     else:
         params, train_loss, val_loss = results
         batch_stats = None
-        trained_net = net
 
     if save_params is not None:
         jnp.save(
@@ -350,16 +312,15 @@ def train_and_eval(
 
     key, subkey = random.split(key)
     test_loss = ml.map_in_batches(
-        partial(map_and_loss, net=trained_net), 
+        partial(map_and_loss, net=net), 
         params, 
         test_X, 
         test_Y, 
         batch_size, 
         subkey, 
         False,
-        has_aux,
-        batch_stats,
-        sharding,
+        has_aux=has_aux,
+        aux_data=batch_stats,
     )
     print(f'Test Loss: {test_loss}')
 
@@ -440,13 +401,6 @@ train_X, train_Y, val_X, val_Y, test_X, test_Y = get_data(data_dir, train_traj, 
 group_actions = geom.make_all_operators(D)
 conv_filters = geom.get_invariant_filters(Ms=[3], ks=[0,1,2], parities=[0,1], D=D, operators=group_actions)
 
-# This section below demonstrates how to shard across multiple GPUs. 
-# Create a Sharding object to distribute a value across devices:
-num_gpus = jax.device_count()
-print('Num gpus: ', num_gpus)
-sharding = PositionalSharding(mesh_utils.create_device_mesh((num_gpus,)))
-conv_filters = conv_filters.device_replicate(sharding)
-
 train_and_eval = partial(
     train_and_eval, 
     lr=lr,
@@ -454,34 +408,33 @@ train_and_eval = partial(
     epochs=epochs, 
     save_params=save_file, 
     images_dir=images_dir,
-    sharding=sharding,
 )
 
 models = [
-    # (
-    #     'GI-Net',
-    #     partial(
-    #         train_and_eval, 
-    #         net=partial(gi_net, conv_filters=conv_filters, depth=10), 
-    #         model_name='gi_net',
-    #     ),
-    # ),
-    # (
-    #     'GI-Net Odd',
-    #     partial(
-    #         train_and_eval, 
-    #         net=partial(gi_net, conv_filters=conv_filters, depth=10, use_odd_parity=True),
-    #         model_name='gi_net_odd',
-    #     ),
-    # ),
-    # (
-    #     'Dil-ResNet',
-    #     partial(
-    #         train_and_eval, 
-    #         net=dil_resnet, 
-    #         model_name='dil_resnet',
-    #     ),
-    # ),
+    (
+        'GI-Net',
+        partial(
+            train_and_eval, 
+            net=partial(gi_net, conv_filters=conv_filters, depth=10), 
+            model_name='gi_net',
+        ),
+    ),
+    (
+        'GI-Net Odd',
+        partial(
+            train_and_eval, 
+            net=partial(gi_net, conv_filters=conv_filters, depth=10, use_odd_parity=True),
+            model_name='gi_net_odd',
+        ),
+    ),
+    (
+        'Dil-ResNet',
+        partial(
+            train_and_eval, 
+            net=dil_resnet, 
+            model_name='dil_resnet',
+        ),
+    ),
     (
         'U-Net 2015',
         partial(

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -1637,6 +1637,9 @@ class Layer:
         Get the spatial dimensions. Use this function with caution, if the layer is being vmapped, it will
         return the incorrect spatial dims.
         """
+        if len(self.values()) == 0:
+            return None
+        
         return next(iter(self.values())).shape[1:1+self.D]
 
     # Functions that map directly to calling the function on data
@@ -1841,6 +1844,9 @@ class BatchLayer(Layer):
         Get the spatial dims. Use this function with caution, if the BatchLayer is being vmapped, then
         it will give you the incorrect spatial dims.
         """
+        if len(self.values()) == 0:
+            return None
+        
         return next(iter(self.values())).shape[2:2+self.D]
 
     def get_subset(self, idxs):

--- a/src/geometricconvolutions/models.py
+++ b/src/geometricconvolutions/models.py
@@ -1,0 +1,137 @@
+import functools
+from collections import defaultdict
+
+import jax.numpy as jnp
+import jax
+
+import geometricconvolutions.geometric as geom
+import geometricconvolutions.ml as ml
+
+def unet_conv_block(
+    params, 
+    layer, 
+    train, 
+    num_conv, 
+    conv_args, 
+    conv_kwargs, 
+    batch_stats=None, 
+    batch_stats_idx=None, 
+    activation_f=None,
+    mold_params=False,
+):
+    for _ in range(num_conv):
+        layer, params = ml.batch_conv_layer(
+            params, 
+            layer,
+            *conv_args,
+            **conv_kwargs,
+            mold_params=mold_params,
+        )
+        if batch_stats is not None:
+            layer, params, mean, var = ml.batch_norm(
+                params, 
+                layer, 
+                train, 
+                batch_stats[batch_stats_idx]['mean'],
+                batch_stats[batch_stats_idx]['var'],
+                mold_params=mold_params,
+            )
+            batch_stats[batch_stats_idx] = { 'mean': mean, 'var': var }
+            batch_stats_idx += 1
+        if activation_f is not None:
+            layer = ml.batch_scalar_activation(layer, activation_f)
+
+    return layer, params, batch_stats, batch_stats_idx
+
+@functools.partial(jax.jit, static_argnums=[3,5,6])
+def unet2015(params, layer, key, train, batch_stats=None, depth=64, activation_f=jax.nn.gelu, return_params=False):
+    num_downsamples = 4
+    num_conv = 2
+
+    # convert to channels of a scalar layer
+    layer = layer.to_scalar_layer()
+
+    batch_stats_idx = 0
+    if batch_stats is None:
+        batch_stats = defaultdict(lambda: { 'mean': None, 'var': None })
+
+    # first we do the downsampling
+    residual_layers = []
+    for downsample in range(num_downsamples):
+        layer, params, batch_stats, batch_stats_idx = unet_conv_block(
+            params, 
+            layer, 
+            train, 
+            num_conv, 
+            [{ 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } }], # conv_args
+            { 'depth': depth*(2**downsample) }, # conv_kwargs
+            batch_stats,
+            batch_stats_idx,
+            activation_f,
+            mold_params=return_params,
+        )
+        residual_layers.append(layer)
+        layer = ml.batch_max_pool(layer, 2)
+
+    # bottleneck layer
+    layer, params, batch_stats, batch_stats_idx = unet_conv_block(
+        params, 
+        layer, 
+        train, 
+        num_conv, 
+        [{ 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } }], # conv_args
+        { 'depth': depth*(2**num_downsamples) }, # conv_kwargs
+        batch_stats,
+        batch_stats_idx,
+        activation_f,
+        mold_params=return_params,
+    )
+
+    # now we do the upsampling and concatenation
+    for upsample in reversed(range(num_downsamples)):
+
+        # upsample
+        layer, params = ml.batch_conv_layer(
+            params, 
+            layer,
+            { 'type': 'free', 'M': 2, 'filter_key_set': { (0,0) } },
+            depth*(2**upsample),
+            padding=((1,1),)*layer.D,
+            lhs_dilation=(2,)*layer.D, # do the transposed convolution
+            mold_params=return_params,
+        )
+        # concat the upsampled layer and the residual
+        layer = jax.vmap(lambda layer1, layer2: layer1.concat(layer2))(layer, residual_layers[upsample])
+
+        layer, params, batch_stats, batch_stats_idx = unet_conv_block(
+            params, 
+            layer, 
+            train, 
+            num_conv, 
+            [{ 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } }], # conv_args
+            { 'depth': depth*(2**upsample) }, # conv_kwargs
+            batch_stats,
+            batch_stats_idx,
+            activation_f,
+            mold_params=return_params,
+        )
+
+    layer, params = ml.batch_conv_layer(
+        params, 
+        layer,
+        { 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } },
+        3, # number of output channels, one scalar and 2 vector
+        mold_params=return_params,
+    )
+
+    # swap the vector back to the vector img
+    layer = geom.BatchLayer(
+        {
+            (0,0): jnp.expand_dims(layer[(0,0)][:,0], axis=1),
+            (1,0): jnp.expand_dims(layer[(0,0)][:,1:].transpose((0,2,3,1)), axis=1),
+        },
+        layer.D,
+        layer.is_torus,
+    )
+
+    return (layer, batch_stats, params) if return_params else (layer, batch_stats)

--- a/src/geometricconvolutions/models.py
+++ b/src/geometricconvolutions/models.py
@@ -43,7 +43,7 @@ def unet_conv_block(
 
     return layer, params, batch_stats, batch_stats_idx
 
-@functools.partial(jax.jit, static_argnums=[3,5,6])
+@functools.partial(jax.jit, static_argnums=[3,5,6,7])
 def unet2015(params, layer, key, train, batch_stats=None, depth=64, activation_f=jax.nn.gelu, return_params=False):
     num_downsamples = 4
     num_conv = 2

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -137,10 +137,10 @@ class TestLayer:
 
         # N is set by append if it is empty
         layer2 = layer1.empty()
-        assert layer2.spatial_dims is None
+        assert layer2.get_spatial_dims() is None
 
         layer2.append(0, 0, random.normal(key, shape=((10,) + (N,)*D + (D,)*0)))
-        assert layer2.spatial_dims == (N,)*D
+        assert layer2.get_spatial_dims() == (N,)*D
 
     def testAdd(self):
         key = random.PRNGKey(time.time_ns())
@@ -232,6 +232,25 @@ class TestLayer:
 
         assert rand_layer.size() == layer_example.size()
         assert jnp.allclose(rand_layer.to_vector(), rand_data)
+
+    def testToScalarLayer(self):
+        D = 2
+        N = 5
+
+        layer_example = geom.Layer(
+            {
+                (0,0): jnp.ones((1,) + (N,)*D),
+                (1,0): jnp.ones((1,) + (N,)*D + (D,)),
+                (2,0): jnp.ones((1,) + (N,)*D + (D,D)),
+            },
+            D,
+        )
+
+        scalar_layer = layer_example.to_scalar_layer()
+
+        assert len(scalar_layer.keys()) == 1
+        assert next(iter(scalar_layer.keys())) == (0,0)
+        assert jnp.allclose(scalar_layer[(0,0)], jnp.ones((1+D+D*D,) + (N,)*D))
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Test BatchLayer


### PR DESCRIPTION
## Changes
- implement a U-Net in models.py
- require literal padding when doing transposed convolution, currently don't allow TORUS or SAME
- fix max_pool layer
- implement a method to convert a general layer to a scalar layer, where all components are now scalar channels
- swap conv_contract to add output layers from multiple sources together, rather than concatenate them. If the depth is unchanged, this will reduce expressibility. However, if the depth is doubled, then this is the same up to a change in parameterization. It will also allow for more predictable depth counts.

## Testing
- pytest
- run turb2d script with two models active

## Doc Changes