### PR TITLE
add sharding through pmap, add unet_equiv

### DIFF
--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -1139,9 +1139,6 @@ class GeometricImage:
         """
         return self.D ** self.k
 
-    def spatial_size(self):
-        return np.multiply.reduce(self.spatial_dims)
-
     def __str__(self):
         return "<{} object in D={} with spatial_dims={}, k={}, parity={}, is_torus={}>".format(
             self.__class__, self.D, self.spatial_dims, self.k, self.parity, self.is_torus)
@@ -1444,9 +1441,6 @@ class GeometricFilter(GeometricImage):
         super(GeometricFilter, self).__init__(data, parity, D, is_torus)
         assert self.spatial_dims == (self.spatial_dims[0],)*self.D, \
         "GeometricFilter: Filters must be square." # I could remove  this requirement in the future
-        # self.m = (self.spatial_dims[0] - 1) // 2
-        # assert self.spatial_dims[0] == 2 * self.m + 1, \
-        # "GeometricFilter: N needs to be odd."
 
     @classmethod
     def from_image(cls, geometric_image):

--- a/src/geometricconvolutions/models.py
+++ b/src/geometricconvolutions/models.py
@@ -17,10 +17,12 @@ def unet_conv_block(
     batch_stats=None, 
     batch_stats_idx=None, 
     activation_f=None,
+    equivariant=False,
     mold_params=False,
 ):
+    conv_f = ml.batch_conv_contract if equivariant else ml.batch_conv_layer
     for _ in range(num_conv):
-        layer, params = ml.batch_conv_layer(
+        layer, params = conv_f(
             params, 
             layer,
             *conv_args,
@@ -135,3 +137,88 @@ def unet2015(params, layer, key, train, batch_stats=None, depth=64, activation_f
     )
 
     return (layer, batch_stats, params) if return_params else (layer, batch_stats)
+
+@functools.partial(jax.jit, static_argnums=[3,6,7,8])
+def unet2015_equiv(
+    params, 
+    layer, 
+    key, 
+    train, 
+    conv_filters, 
+    upsample_filters, # 2x2 filters
+    depth=64, 
+    activation_f=jax.nn.gelu, 
+    return_params=False,
+):
+    num_downsamples = 4
+    num_conv = 2
+
+    # first we do the downsampling
+    residual_layers = []
+    for downsample in range(num_downsamples):
+        layer, params, _, _ = unet_conv_block(
+            params, 
+            layer, 
+            train, 
+            num_conv, 
+            [conv_filters], # conv_args
+            { 'depth': depth*(2**downsample), 'target_keys': ((0,0),(1,0)) }, # conv_kwargs
+            activation_f=activation_f,
+            equivariant=True,
+            mold_params=return_params,
+        )
+        residual_layers.append(layer)
+        layer = ml.batch_max_pool(layer, 2)
+
+    # bottleneck layer
+    layer, params, _, _ = unet_conv_block(
+        params, 
+        layer, 
+        train, 
+        num_conv, 
+        [conv_filters], # conv_args
+        { 'depth': depth*(2**num_downsamples), 'target_keys': ((0,0),(1,0)) }, # conv_kwargs
+        activation_f=activation_f,
+        equivariant=True,
+        mold_params=return_params,
+    )
+
+    # now we do the upsampling and concatenation
+    for upsample in reversed(range(num_downsamples)):
+
+        # upsample
+        layer, params = ml.batch_conv_contract(
+            params, 
+            layer,
+            upsample_filters,
+            depth*(2**upsample),
+            ((0,0),(1,0)),
+            padding=((1,1),)*layer.D,
+            lhs_dilation=(2,)*layer.D, # do the transposed convolution
+            mold_params=return_params,
+        )
+        # concat the upsampled layer and the residual
+        layer = jax.vmap(lambda layer1, layer2: layer1.concat(layer2))(layer, residual_layers[upsample])
+
+        layer, params, _, _ = unet_conv_block(
+            params, 
+            layer, 
+            train, 
+            num_conv, 
+            [conv_filters], # conv_args
+            { 'depth': depth*(2**upsample), 'target_keys': ((0,0),(1,0)) }, # conv_kwargs
+            activation_f=activation_f,
+            equivariant=True,
+            mold_params=return_params,
+        )
+
+    layer, params = ml.batch_conv_contract(
+        params, 
+        layer,
+        conv_filters,
+        1,
+        ((0,0),(1,0)),
+        mold_params=return_params,
+    )
+
+    return (layer, params) if return_params else layer

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,8 +1,12 @@
+import os
+
 import jax.numpy as jnp
 from jax import random
 
 import geometricconvolutions.geometric as geom
 import geometricconvolutions.ml as ml
+
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
 class TestMachineLearning:
     # Class to test the functions in the ml.py file, which include layers, data pre-processing, batching, etc.
@@ -48,31 +52,33 @@ class TestMachineLearning:
         assert Y[-2][1] == X[0]
 
     def testGetBatchLayer(self):
+        num_devices = 1 # since we set CUDA_VISIBLE_DEVICES=-1, it only can see the cpu
+
         key = random.PRNGKey(0)
         N = 5
         D = 2
         k = 0
 
-        X = geom.BatchLayer({ k: random.normal(key, shape=((10,1) + (N,)*D + (D,)*k)) }, D)
-        Y = geom.BatchLayer({ k: random.normal(key, shape=((10,1) + (N,)*D + (D,)*k)) }, D)
+        X = geom.BatchLayer({ (k,0): random.normal(key, shape=((10,1) + (N,)*D + (D,)*k)) }, D)
+        Y = geom.BatchLayer({ (k,0): random.normal(key, shape=((10,1) + (N,)*D + (D,)*k)) }, D)
 
         batch_size = 2
         X_batches, Y_batches = ml.get_batch_layer(X, Y, batch_size=batch_size, rand_key=key)
         assert len(X_batches) == len(Y_batches) == 5
         for X_batch, Y_batch in zip(X_batches, Y_batches):
-            assert X_batch[k].shape == Y_batch[k].shape == (batch_size, 1) + (N,)*D + (D,)*k
+            assert X_batch[(k,0)].shape == Y_batch[(k,0)].shape == (num_devices, batch_size, 1) + (N,)*D + (D,)*k
 
         X = geom.BatchLayer(
             { 
-                0: random.normal(key, shape=((20,1) + (N,)*D + (D,)*0)),
-                1: random.normal(key, shape=((20,1) + (N,)*D + (D,)*1)),
+                (0,0): random.normal(key, shape=((20,1) + (N,)*D + (D,)*0)),
+                (1,0): random.normal(key, shape=((20,1) + (N,)*D + (D,)*1)),
             },
             D,
         )
         Y = geom.BatchLayer(
             { 
-                0: random.normal(key, shape=((20,1) + (N,)*D + (D,)*0)),
-                1: random.normal(key, shape=((20,1) + (N,)*D + (D,)*1)),
+                (0,0): random.normal(key, shape=((20,1) + (N,)*D + (D,)*0)),
+                (1,0): random.normal(key, shape=((20,1) + (N,)*D + (D,)*1)),
             },
             D,
         )
@@ -82,20 +88,20 @@ class TestMachineLearning:
         X_batches, Y_batches = ml.get_batch_layer(X, Y, batch_size=batch_size, rand_key=key)
         assert len(X_batches) == len(Y_batches) == 4
         for X_batch, Y_batch in zip(X_batches, Y_batches):
-            assert X_batch[0].shape == Y_batch[0].shape == (batch_size, 1) + (N,)*D + (D,)*0
-            assert X_batch[1].shape == Y_batch[1].shape == (batch_size, 1) + (N,)*D + (D,)*1
+            assert X_batch[(0,0)].shape == Y_batch[(0,0)].shape == (num_devices, batch_size, 1) + (N,)*D + (D,)*0
+            assert X_batch[(1,0)].shape == Y_batch[(1,0)].shape == (num_devices, batch_size, 1) + (N,)*D + (D,)*1
 
         X = geom.BatchLayer(
             { 
-                0: random.normal(key, shape=((20,2) + (N,)*D + (D,)*0)),
-                1: random.normal(key, shape=((20,1) + (N,)*D + (D,)*1)),
+                (0,0): random.normal(key, shape=((20,2) + (N,)*D + (D,)*0)),
+                (1,0): random.normal(key, shape=((20,1) + (N,)*D + (D,)*1)),
             },
             D,
         )
         Y = geom.BatchLayer(
             { 
-                0: random.normal(key, shape=((20,2) + (N,)*D + (D,)*0)),
-                1: random.normal(key, shape=((20,1) + (N,)*D + (D,)*1)),
+                (0,0): random.normal(key, shape=((20,2) + (N,)*D + (D,)*0)),
+                (1,0): random.normal(key, shape=((20,1) + (N,)*D + (D,)*1)),
             },
             D,
         )
@@ -105,6 +111,6 @@ class TestMachineLearning:
         X_batches, Y_batches = ml.get_batch_layer(X, Y, batch_size=batch_size, rand_key=key)
         assert len(X_batches) == len(Y_batches) == 4
         for X_batch, Y_batch in zip(X_batches, Y_batches):
-            assert X_batch[0].shape == Y_batch[0].shape == (batch_size, 2) + (N,)*D + (D,)*0
-            assert X_batch[1].shape == Y_batch[1].shape == (batch_size, 1) + (N,)*D + (D,)*1
+            assert X_batch[(0,0)].shape == Y_batch[(0,0)].shape == (num_devices, batch_size, 2) + (N,)*D + (D,)*0
+            assert X_batch[(1,0)].shape == Y_batch[(1,0)].shape == (num_devices, batch_size, 1) + (N,)*D + (D,)*1
             


### PR DESCRIPTION
## Changes
- make print image optional for gravity, especially because it is broken right now
- write the U-Net equivariant model. Currently for memory reasons it has to be at depth=32 instead of depth=64
- rework convolve and convolve_contract so that they don't duplicate code. Now convolve optionally doesn't expand the tensor so that we can do it differently in convolve_contract, and then convolve_contract can just call convolve with the right arguments.
- allow GeometricFilter to have even side lengths, remove some unused code
- require literal padding when using filters with even sides
- do automatic batch sharding using pmap in train
- fix batch_norm to work with pmap

## Testing
- pytest
- run gravity_field with different options of visible gpus: 1, 2, 0, or 2 specified by devices
- run turb2d with unet2015 and unet2015_equiv

## Doc Changes
- none