### PR TITLE
allow partial toruses

### DIFF
--- a/scripts/shallow_water.py
+++ b/scripts/shallow_water.py
@@ -370,7 +370,7 @@ models = [
         'Dil-ResNet',
         partial(
             train_and_eval, 
-            net=models.dil_resnet, 
+            net=partial(models.dil_resnet, depth=128, activation_f=jax.nn.gelu),
             model_name='dil_resnet',
         ),
     ),
@@ -378,7 +378,13 @@ models = [
         'Dil-ResNet Equiv',
         partial(
             train_and_eval, 
-            net=partial(models.dil_resnet, equivariant=True, conv_filters=conv_filters),
+            net=partial(
+                models.dil_resnet, 
+                depth=128, 
+                activation_f=jax.nn.gelu, 
+                equivariant=True, 
+                conv_filters=conv_filters,
+            ),
             model_name='dil_resnet_equiv',
         ),
     ),

--- a/src/geometricconvolutions/models.py
+++ b/src/geometricconvolutions/models.py
@@ -219,6 +219,20 @@ def dil_resnet(
     return_params=False,
 ):
     """
+    The DilatedResNet from https://arxiv.org/pdf/2112.15275.pdf. There are 4 dilated resnet blocks. There 
+    7 dilated convoltions that are [1,2,4,8,4,2,1] with biases, each followed by an activation function.
+    The residual layers are then added (not concatenated) back at the end of the block. There is a single 
+    convolution (with bias) at the beginning and end to encode and decode. The 
+    args:
+        params (params tree): the params of the model
+        layer (BatchLayer): input batch layer
+        key (jnp.random key): key for any layers requiring randomization
+        train (bool): whether train mode or test mode, relevant for batch_norm
+        depth (int): the depth of the layers, defaults to 48
+        activaton_f (function): the function that we pass to batch_scalar_activation, defaults to relu
+        equivariant (bool): whether to use the equivariant version of the model, defaults to False
+        conv_filters (Layer): the conv filters used for the equivariant version
+        return_params (bool): whether we are mapping the params, or applying them
     """
     assert layer.D == 2
     num_blocks = 4

--- a/src/geometricconvolutions/models.py
+++ b/src/geometricconvolutions/models.py
@@ -12,20 +12,32 @@ def unet_conv_block(
     layer, 
     train, 
     num_conv, 
-    conv_args, 
+    conv_f,
     conv_kwargs, 
     batch_stats=None, 
     batch_stats_idx=None, 
     activation_f=None,
-    equivariant=False,
     mold_params=False,
 ):
-    conv_f = ml.batch_conv_contract if equivariant else ml.batch_conv_layer
+    """
+    The Conv block for the U-Net, include batch norm and an activation function.
+    args:
+        params (params tree): the params of the model
+        layer (BatchLayer): input batch layer
+        train (bool): whether train mode or test mode, relevant for batch_norm
+        num_conv (int): the number of convolutions, how many times to repeat the block
+        conv_f (function): the conv function
+        conv_kwargs (dict): keyword args to pass the the convolution function
+        batch_stats (dict): state for batch_norm, also determines whether batch_norm layer happens
+        batch_stats_idx (int): the index of batch_norm that we are on
+        activaton_f (function): the function that we pass to batch_scalar_activation
+        mold_params (bool): whether we are mapping the params, or applying them
+    returns: layer, params, batch_stats, batch_stats_idx 
+    """
     for _ in range(num_conv):
         layer, params = conv_f(
             params, 
             layer,
-            *conv_args,
             **conv_kwargs,
             mold_params=mold_params,
         )
@@ -45,17 +57,61 @@ def unet_conv_block(
 
     return layer, params, batch_stats, batch_stats_idx
 
-@functools.partial(jax.jit, static_argnums=[3,5,6,7])
-def unet2015(params, layer, key, train, batch_stats=None, depth=64, activation_f=jax.nn.gelu, return_params=False):
+@functools.partial(jax.jit, static_argnums=[3,5,6,7,10,11])
+def unet2015(
+    params, 
+    layer, 
+    key, 
+    train, 
+    batch_stats=None,
+    depth=64, 
+    activation_f=jax.nn.gelu,
+    equivariant=False,
+    conv_filters=None, 
+    upsample_filters=None, # 2x2 filters
+    target_keys=None,
+    return_params=False,
+):
+    """
+    The U-Net from the original 2015 paper. The involves 4 downsampling steps and 4 upsampling steps, 
+    each interspersed with 2 convolutions interleaved with scalar activations and batch norm. The downsamples
+    are achieved with max_pool layers with patch length of 2 and the upsamples are achieved with transposed
+    convolution. Additionally, there are residual connections after every downsample and upsample. For the 
+    equivariant version, we use invariant filters, norm max_pool, and no batch_norm.
+    args:
+        params (params tree): the params of the model
+        layer (BatchLayer): input batch layer
+        key (jnp.random key): key for any layers requiring randomization
+        train (bool): whether train mode or test mode, relevant for batch_norm
+        batch_stats (dict): state for batch_norm, default None
+        depth (int): the depth of the layers, defaults to 64
+        activaton_f (function): the function that we pass to batch_scalar_activation
+        equivariant (bool): whether to use the equivariant version of the model, defaults to False
+        conv_filters (Layer): the conv filters used for the equivariant version
+        upsample_filters (Layer): the conv filters used for the upsample layer of the equivariant version
+        target_keys (tuple of tuples of ints): the output key types of the model. For the Shallow Water
+            experiments, should be ((0,0),(1,0)) for the pressure/velocity form and ((0,0),(0,1)) for 
+            the pressure/vorticity form.
+        return_params (bool): whether we are mapping the params, or applying them
+    """
     num_downsamples = 4
     num_conv = 2
 
-    # convert to channels of a scalar layer
-    layer = layer.to_scalar_layer()
-
     batch_stats_idx = 0
-    if batch_stats is None:
-        batch_stats = defaultdict(lambda: { 'mean': None, 'var': None })
+    if equivariant:
+        assert (conv_filters is not None) and (upsample_filters is not None) and (target_keys is not None)
+        conv_f = ml.batch_conv_contract
+        conv_kwargs = { 'invariant_filters': conv_filters, 'target_keys': target_keys }
+        upsample_conv_kwargs = { 'invariant_filters': upsample_filters, 'target_keys': target_keys }
+    else:
+        conv_f = ml.batch_conv_layer
+        conv_kwargs = { 'filter_info': { 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } } }
+        upsample_conv_kwargs = { 'filter_info': { 'type': 'free', 'M': 2, 'filter_key_set': { (0,0) } } }
+        if batch_stats is None:
+            batch_stats = defaultdict(lambda: { 'mean': None, 'var': None })
+
+        # convert to channels of a scalar layer
+        layer = layer.to_scalar_layer()
 
     # first we do the downsampling
     residual_layers = []
@@ -65,15 +121,15 @@ def unet2015(params, layer, key, train, batch_stats=None, depth=64, activation_f
             layer, 
             train, 
             num_conv, 
-            [{ 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } }], # conv_args
-            { 'depth': depth*(2**downsample), 'padding': 'SAME' }, # conv_kwargs
+            conv_f,
+            { **conv_kwargs, 'depth': depth*(2**downsample) },
             batch_stats,
             batch_stats_idx,
             activation_f,
             mold_params=return_params,
         )
         residual_layers.append(layer)
-        layer = ml.batch_max_pool(layer, 2, use_norm=False)
+        layer = ml.batch_max_pool(layer, 2, use_norm=equivariant)
 
     # bottleneck layer
     layer, params, batch_stats, batch_stats_idx = unet_conv_block(
@@ -81,8 +137,8 @@ def unet2015(params, layer, key, train, batch_stats=None, depth=64, activation_f
         layer, 
         train, 
         num_conv, 
-        [{ 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } }], # conv_args
-        { 'depth': depth*(2**num_downsamples), 'padding': 'SAME' }, # conv_kwargs
+        conv_f,
+        { **conv_kwargs, 'depth': depth*(2**num_downsamples) },
         batch_stats,
         batch_stats_idx,
         activation_f,
@@ -93,11 +149,11 @@ def unet2015(params, layer, key, train, batch_stats=None, depth=64, activation_f
     for upsample in reversed(range(num_downsamples)):
 
         # upsample
-        layer, params = ml.batch_conv_layer(
+        layer, params = conv_f(
             params, 
             layer,
-            { 'type': 'free', 'M': 2, 'filter_key_set': { (0,0) } },
-            depth*(2**upsample),
+            **upsample_conv_kwargs,
+            depth=depth*(2**upsample),
             padding=((1,1),)*layer.D,
             lhs_dilation=(2,)*layer.D, # do the transposed convolution
             mold_params=return_params,
@@ -110,119 +166,45 @@ def unet2015(params, layer, key, train, batch_stats=None, depth=64, activation_f
             layer, 
             train, 
             num_conv, 
-            [{ 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } }], # conv_args
-            { 'depth': depth*(2**upsample), 'padding': 'SAME' }, # conv_kwargs
+            conv_f,
+            { **conv_kwargs, 'depth': depth*(2**upsample) },
             batch_stats,
             batch_stats_idx,
             activation_f,
             mold_params=return_params,
         )
 
-    layer, params = ml.batch_conv_layer(
-        params, 
-        layer,
-        { 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } },
-        3, # number of output channels, one scalar and 2 vector
-        padding='SAME',
-        mold_params=return_params,
-    )
-
-    # swap the vector back to the vector img
-    layer = geom.BatchLayer(
-        {
-            (0,0): jnp.expand_dims(layer[(0,0)][:,0], axis=1),
-            (1,0): jnp.expand_dims(layer[(0,0)][:,1:].transpose((0,2,3,1)), axis=1),
-        },
-        layer.D,
-        layer.is_torus,
-    )
-
-    return (layer, batch_stats, params) if return_params else (layer, batch_stats)
-
-@functools.partial(jax.jit, static_argnums=[3,6,7,8])
-def unet2015_equiv(
-    params, 
-    layer, 
-    key, 
-    train, 
-    conv_filters, 
-    upsample_filters, # 2x2 filters
-    depth=64, 
-    activation_f=jax.nn.gelu, 
-    return_params=False,
-):
-    num_downsamples = 4
-    num_conv = 2
-
-    # first we do the downsampling
-    residual_layers = []
-    for downsample in range(num_downsamples):
-        layer, params, _, _ = unet_conv_block(
-            params, 
-            layer, 
-            train, 
-            num_conv, 
-            [conv_filters], # conv_args
-            { 'depth': depth*(2**downsample), 'target_keys': ((0,0),(1,0)) }, # conv_kwargs
-            activation_f=activation_f,
-            equivariant=True,
-            mold_params=return_params,
-        )
-        residual_layers.append(layer)
-        layer = ml.batch_max_pool(layer, 2)
-
-    # bottleneck layer
-    layer, params, _, _ = unet_conv_block(
-        params, 
-        layer, 
-        train, 
-        num_conv, 
-        [conv_filters], # conv_args
-        { 'depth': depth*(2**num_downsamples), 'target_keys': ((0,0),(1,0)) }, # conv_kwargs
-        activation_f=activation_f,
-        equivariant=True,
-        mold_params=return_params,
-    )
-
-    # now we do the upsampling and concatenation
-    for upsample in reversed(range(num_downsamples)):
-
-        # upsample
-        layer, params = ml.batch_conv_contract(
+    if equivariant:
+        layer, params = conv_f(
             params, 
             layer,
-            upsample_filters,
-            depth*(2**upsample),
-            ((0,0),(1,0)),
-            padding=((1,1),)*layer.D,
-            lhs_dilation=(2,)*layer.D, # do the transposed convolution
+            **conv_kwargs,
+            depth=1,
             mold_params=return_params,
         )
-        # concat the upsampled layer and the residual
-        layer = jax.vmap(lambda layer1, layer2: layer1.concat(layer2))(layer, residual_layers[upsample])
-
-        layer, params, _, _ = unet_conv_block(
+    else:
+        final_depth = 3 if target_keys == ((0,0),(1,0)) else 2
+        layer, params = conv_f(
             params, 
-            layer, 
-            train, 
-            num_conv, 
-            [conv_filters], # conv_args
-            { 'depth': depth*(2**upsample), 'target_keys': ((0,0),(1,0)) }, # conv_kwargs
-            activation_f=activation_f,
-            equivariant=True,
+            layer,
+            { 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } },
+            final_depth, # number of output channels, either scalar/pseudoscalar or scalar/vector
             mold_params=return_params,
         )
 
-    layer, params = ml.batch_conv_contract(
-        params, 
-        layer,
-        conv_filters,
-        1,
-        ((0,0),(1,0)),
-        mold_params=return_params,
-    )
+        # swap the vector back to the vector img
+        layer = layer.from_scalar_layer({ key: 1 for key in target_keys })
 
-    return (layer, params) if return_params else layer
+    if (batch_stats is not None) or return_params:
+        res = (layer,)
+        if batch_stats is not None:
+            res = res + (batch_stats,)
+        if return_params:
+            res = res + (params,)
+    else:
+        res = layer
+
+    return res
 
 @functools.partial(jax.jit, static_argnums=[3,4,5,6,8])
 def dil_resnet(
@@ -236,6 +218,8 @@ def dil_resnet(
     conv_filters=None, 
     return_params=False,
 ):
+    """
+    """
     assert layer.D == 2
     num_blocks = 4
 
@@ -243,17 +227,19 @@ def dil_resnet(
         assert conv_filters is not None
         conv_f = ml.batch_conv_contract
         conv_args = [conv_filters, depth, ((0,0),(1,0))]
+        bias = False
     else:
         layer = layer.to_scalar_layer()
         conv_f = ml.batch_conv_layer
         conv_args = [{ 'type': 'free', 'M': 3, 'filter_key_set': { (0,0) } }, depth]
+        bias = True
 
     # encoder
     layer, params = conv_f(
         params, 
         layer,
         *conv_args,
-        bias=False if equivariant else True,
+        bias=bias,
         mold_params=return_params,
     )
 
@@ -267,7 +253,7 @@ def dil_resnet(
                 params, 
                 layer,
                 *conv_args,
-                bias=False if equivariant else True,
+                bias=bias,
                 mold_params=return_params,
                 rhs_dilation=(dilation,)*layer.D,
             )

--- a/tests/test_functional_geometric_image.py
+++ b/tests/test_functional_geometric_image.py
@@ -131,7 +131,7 @@ class TestFunctionalGeometricImage:
         in_c = 1
         out_c = 1
         batch = 1
-        is_torus = True
+        is_torus = (True,)*D
         key = random.PRNGKey(time.time_ns())
         
         for img_k in range(4):
@@ -163,7 +163,7 @@ class TestFunctionalGeometricImage:
         in_c = 1
         out_c = 1
         batch = 1
-        is_torus = True
+        is_torus = (True,)*D
         key = random.PRNGKey(time.time_ns())
         
         for img_k in range(3):
@@ -216,7 +216,7 @@ class TestFunctionalGeometricImage:
         ]])
         assert filter_data.shape == (1,2,3,3)
 
-        convolved_image = geom.convolve(2, image_data, filter_data, is_torus=True)
+        convolved_image = geom.convolve(2, image_data, filter_data, is_torus=(True,)*2)
         assert convolved_image.shape == (1,1,3,3)
         assert jnp.allclose(
             convolved_image,
@@ -256,7 +256,7 @@ class TestFunctionalGeometricImage:
             ], 
         ]])
 
-        convolved_image = geom.convolve(2, image_data, filter_image, is_torus=True)
+        convolved_image = geom.convolve(2, image_data, filter_image, is_torus=(True,)*2)
         assert convolved_image.shape == (1,1,3,3,2)
         assert jnp.allclose(
             convolved_image,

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -16,14 +16,14 @@ class TestLayer:
 
         layer1 = geom.Layer({}, D, False)
         assert layer1.D == D
-        assert layer1.is_torus == False 
+        assert layer1.is_torus == (False,)*D
         for _, _ in layer1.items():
             assert False # its empty, so this won't ever be called
 
         k = 0
         layer2 = geom.Layer({ k: random.normal(key, shape=((1,) + (N,)*D + (D,)*k)) }, D, False)
         assert layer2.D == D
-        assert layer2.is_torus == False
+        assert layer2.is_torus == (False,)*D
         assert layer2[0].shape == (1,N,N)
 
         #layers can have multiple k values, and can have different size channels at each k
@@ -38,7 +38,7 @@ class TestLayer:
         assert list(layer3.keys()) == [0,1]
         assert layer3[0].shape == (10, N, N)
         assert layer3[1].shape == (3, N, N, D)
-        assert layer3.is_torus == True
+        assert layer3.is_torus == (True,)*D
 
     def testCopy(self):
         key = random.PRNGKey(time.time_ns())
@@ -70,7 +70,7 @@ class TestLayer:
         images = [geom.GeometricImage(data, 0, D) for data in random_data]
         layer1 = geom.Layer.from_images(images)
         assert layer1.D == D 
-        assert layer1.is_torus == True
+        assert layer1.is_torus == (True,)*D
         assert list(layer1.keys()) == [(1,0)]
         assert layer1[(1,0)].shape == (10, N, N, D)
 
@@ -283,14 +283,14 @@ class TestBatchLayer:
 
         layer1 = geom.BatchLayer({}, D, False)
         assert layer1.D == D
-        assert layer1.is_torus == False 
+        assert layer1.is_torus == (False,)*D
         for _, _ in layer1.items():
             assert False # its empty, so this won't ever be called
 
         k = 0
         layer2 = geom.BatchLayer({ (k,0): random.normal(key, shape=((10,1) + (N,)*D + (D,)*k)) }, D, False)
         assert layer2.D == D
-        assert layer2.is_torus == False
+        assert layer2.is_torus == (False,)*D
         assert layer2[(0,0)].shape == (10,1,N,N)
 
         # layers can have multiple k values with different channels, 
@@ -306,7 +306,7 @@ class TestBatchLayer:
         assert list(layer3.keys()) == [(0,0),(1,0)]
         assert layer3[(0,0)].shape == (5,10, N, N)
         assert layer3[(1,0)].shape == (5,3, N, N, D)
-        assert layer3.is_torus == True
+        assert layer3.is_torus == (True,)*D
 
     def testGetSubset(self):
         key = random.PRNGKey(time.time_ns())
@@ -394,7 +394,7 @@ class TestBatchLayer:
 
         layer3 = layer1 + layer2 
         assert layer3.D == D
-        assert layer3.is_torus == True 
+        assert layer3.is_torus == (True,)*D
         assert layer3[(1,0)].shape == (12,10,N,N,D)
         assert layer3[(2,0)].shape == (12,3,N,N,D,D)
 

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -288,3 +288,20 @@ class TestPropositions:
                         jnp.sqrt(geom.multicontract(geom.mul(D, tensor, tensor), idxs, idx_shift=D)[0,0]),
                     )
 
+    def testMaxPoolEquivariance(self):
+        N = 6
+        key = random.PRNGKey(0)
+        for D in [2,3]:
+            operators = geom.make_all_operators(D)
+            for parity in [0,1]:
+                for k in [0,1,2,3]:
+                    key, subkey = random.split(key)
+                    image = random.normal(subkey, shape=((N,)*D + (D,)*k))
+
+                    # assert that norm is equivariant
+                    for gg in operators:
+                        assert jnp.allclose(
+                            geom.times_group_element(D, geom.max_pool(D, image, 2), parity, gg),
+                            geom.max_pool(D, geom.times_group_element(D, image, parity, gg), 2),
+                        )
+

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -263,3 +263,28 @@ class TestPropositions:
             vmap(lambda vec: geom.multicontract(jnp.tensordot(vec, kd_3, axes=0), ((0,1),)))(flattened_data)
         )
 
+    def testFrobeniusNormEquivariance(self):
+        key = random.PRNGKey(0)
+        for D in [2,3]:
+            operators = geom.make_all_operators(D)
+            for parity in [0,1]:
+                for k in [0,1,2,3]:
+                    key, subkey = random.split(key)
+                    tensor = random.normal(subkey, shape=((1,)*D + (D,)*k))
+
+                    # assert that norm is equivariant
+                    for gg in operators:
+                        assert jnp.allclose(
+                            jnp.linalg.norm(tensor),
+                            jnp.linalg.norm(
+                                geom.times_group_element(D, tensor, parity, gg, jax.lax.Precision.HIGHEST),
+                            ),
+                        )
+
+                    # assert that norm is equivalent to prod, followed by the specific contraction
+                    idxs = tuple((i,j) for i,j in zip(range(k), range(k,2*k)))
+                    assert jnp.allclose(
+                        jnp.linalg.norm(tensor),
+                        jnp.sqrt(geom.multicontract(geom.mul(D, tensor, tensor), idxs, idx_shift=D)[0,0]),
+                    )
+


### PR DESCRIPTION
## Changes
- add skip_initial, subsample, pres_vor_form, and various kinds of normalizing the shallow water experiments
- allow geometric images to be a torus in some dimensions and not in others. This is helpful for the Shallow Water model which is a torus in only the second dimension. Passing True or False will still work, it will just set all of them to that val
- fix a bug with bias img
- remove some unnecessary batch functions
- consolidate unet2015 and unet2015_equiv into a single function. Its a little messy, but I think ultimately better.
- add test for frobenius norm equivariance

## Testing
- run different models for shallow water
- unit tests

## Doc Changes
- none