### PR TITLE
Nonlinear scalars

### DIFF
--- a/scripts/ns_incomp_2d.py
+++ b/scripts/ns_incomp_2d.py
@@ -1,0 +1,475 @@
+import sys
+import time
+import argparse
+import numpy as np
+from functools import partial, reduce
+import h5py
+
+import jax.numpy as jnp
+import jax
+import jax.random as random
+import optax
+
+import geometricconvolutions.geometric as geom
+import geometricconvolutions.data as gc_data
+import geometricconvolutions.ml as ml
+import geometricconvolutions.models as models
+
+def read_one_h5(filename: str) -> tuple:
+    """
+    Given a filename and a type of data (train, test, or validation), read the data and return as jax arrays.
+    args:
+        filename (str): the full file path
+    returns: force, particle, and velocity
+    """
+    data_dict = h5py.File(filename) # keys 'force', 'particles', 't', 'velocity'
+    # 4 runs, 1000 time points, 512x512 grid
+    force = jax.device_put(jnp.array(data_dict['force'][()]), jax.devices('cpu')[0]) # (4,512,512,2)
+    particles = jax.device_put(jnp.array(data_dict['particles'][()]), jax.devices('cpu')[0]) # (4,1000,512,512,1)
+    # these are advected particles, might be a proxy of density?
+    # t = jax.device_put(jnp.array(data_dict['t'][()]), jax.devices('cpu')[0]) # (4,1000)
+    velocity = jax.device_put(jnp.array(data_dict['velocity'][()]), jax.devices('cpu')[0]) # (4,1000,512,512,2)
+
+    data_dict.close()
+
+    return force, particles[...,0], velocity
+
+def get_data_layers(
+    force, 
+    particles, 
+    velocity, 
+    past_steps: int,
+    future_steps: int,
+    skip_initial: int = 0, 
+    subsample: int = 1,
+    downsample: int = 0,
+) -> tuple:
+    """
+    args:
+        force (jnp.array): vector field, constant forcing term, shape (batch,spatial,D)
+        particles (jnp.array): scalar field, advected particle density (batch,time,spatial,D)
+        velocity (jnp.array): vector field, velocity of the fluid (batch,time,spatial,D)
+        past_steps (int): number of historical steps to use in the model
+        future_steps (int): number of future steps
+        skip_intial (int): number of initial time steps to skip, defaults to 0
+        subsample (int): subsample the time dimension, defaults to 1 which is no subsampling
+        downsample (int): number of times to downsample the image by average pooling, decreases by a factor
+            of 2, defaults to 0 times.
+    returns tuple of layer_X, layer_Y
+    """
+    D = 2
+    spatial_dims = force.shape[1:D+1]
+
+    particles = particles[:,skip_initial::subsample]
+    velocity = velocity[:,skip_initial::subsample]
+    # add a time dimension to force and fill it with copies
+    force = jnp.full((len(force),velocity.shape[1]) + force.shape[1:], force[:,None])
+
+    input_window_idxs = gc_data.rolling_window_idx(0, velocity.shape[1]-future_steps, past_steps)
+    input_particles = particles[:, input_window_idxs].reshape((-1, past_steps) + spatial_dims)
+    input_velocity = velocity[:, input_window_idxs].reshape((-1, past_steps) + spatial_dims + (D,))
+    input_force = force[:, input_window_idxs].reshape((-1, past_steps) + spatial_dims + (D,))[:,:1]
+    input_vec = jnp.concatenate([input_velocity, input_force], axis=1) # add forcing term as velocity channel
+
+    output_window_idxs = gc_data.rolling_window_idx(past_steps, velocity.shape[1], future_steps)
+    assert len(output_window_idxs) == len(input_window_idxs)
+    output_particles = particles[:, output_window_idxs].reshape((-1, future_steps) + spatial_dims)
+    output_velocity = velocity[:, output_window_idxs].reshape((-1, future_steps) + spatial_dims + (D,))
+
+    layer_X = geom.BatchLayer({ (0,0): input_particles, (1,0): input_vec }, D, False)
+    layer_Y = geom.BatchLayer({ (0,0): output_particles, (1,0): output_velocity }, D, False)
+
+    for _ in range(downsample):
+        layer_X = ml.batch_average_pool(layer_X, 2)
+        layer_Y = ml.batch_average_pool(layer_Y, 2)
+
+    return layer_X, layer_Y
+
+def get_data(
+    filename: str, 
+    num_train_traj: int, 
+    num_val_traj: int, 
+    num_test_traj: int, 
+    past_steps: int,
+    rollout_steps: int,
+    subsample: int = 1,
+    downsample: int = 0,
+) -> tuple:
+    """
+    Get train, val, and test data sets.
+    args:
+        infile (str): directory of data
+        num_train_traj (int): number of training trajectories
+        num_val_traj (int): number of validation trajectories
+        num_test_traj (int): number of testing trajectories
+        past_steps (int): length of the lookback to predict the next step
+        rollout_steps (int): number of steps of rollout to compare against
+        subsample (int): can subsample for longer timesteps, default 1 (no subsampling)
+        downsample (int): number of times to spatial downsample, defaults to 0 (no downsampling)
+    """
+    f, p, v = read_one_h5(filename)
+
+    start = 0
+    stop = num_train_traj
+    train_X, train_Y = get_data_layers(
+        f[start:stop], 
+        p[start:stop], 
+        v[start:stop], 
+        past_steps, 
+        1, 
+        0, 
+        subsample, 
+        downsample,
+    )
+    start = stop
+    stop = stop + num_val_traj
+    val_X, val_Y = get_data_layers(
+        f[start:stop], 
+        p[start:stop], 
+        v[start:stop], 
+        past_steps, 
+        1, 
+        0, 
+        subsample, 
+        downsample,
+    )
+    start = stop
+    stop = stop + num_test_traj
+    test_single_X, test_single_Y = get_data_layers(
+        f[start:stop], 
+        p[start:stop], 
+        v[start:stop], 
+        past_steps, 
+        1, 
+        0, 
+        subsample,
+        downsample,
+    )
+    test_rollout_X, test_rollout_Y = get_data_layers(
+        f[start:stop], 
+        p[start:stop], 
+        v[start:stop], 
+        past_steps, 
+        rollout_steps, 
+        0, 
+        subsample,
+        downsample,
+    )
+    
+    return train_X, train_Y, val_X, val_Y, test_single_X, test_single_Y, test_rollout_X, test_rollout_Y
+    
+def map_and_loss(params, layer_x, layer_y, key, train, aux_data=None, net=None, has_aux=False, future_steps=1):
+    assert net is not None
+    curr_layer = layer_x
+    out_layer = layer_y.empty()
+    for _ in range(future_steps):
+        key, subkey = random.split(key)
+        if has_aux:
+            learned_x, aux_data = net(params, curr_layer, subkey, train, batch_stats=aux_data)
+        else:
+            learned_x = net(params, curr_layer, subkey, train)
+
+        out_layer = out_layer.concat(learned_x, axis=1)
+        next_layer = curr_layer.empty()
+        next_layer.append(0, 0, jnp.concatenate([curr_layer[(0,0)][:,1:], learned_x[(0,0)]], axis=1))
+        vector_img = curr_layer[(1,0)]
+        next_layer.append(1, 0, jnp.stack([vector_img[:,1], learned_x[(1,0)][:,0], vector_img[:,2]], axis=1))
+        # ^ second time step becomes first, learned step becomes second, forcing field stays as the 3rd channel
+
+        curr_layer = next_layer
+
+    loss = ml.pointwise_normalized_loss(out_layer, layer_y)
+    # loss = ml.smse_loss(out_layer, layer_y)  
+    return (loss, aux_data) if has_aux else loss
+
+def train_and_eval(
+    data, 
+    key, 
+    model_name, 
+    net, 
+    lr,
+    batch_size, 
+    epochs, 
+    save_params, 
+    images_dir, 
+    noise_stdev=None,
+    has_aux=False,
+    verbose=2,
+):
+    train_X, train_Y, val_X, val_Y, test_single_X, test_single_Y, test_rollout_X, test_rollout_Y = data
+
+    key, subkey = random.split(key)
+    params = ml.init_params(
+        net,
+        train_X.get_one(),
+        subkey,
+    )
+    print(f'Model params: {ml.count_params(params):,}')
+
+    steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
+
+    key, subkey = random.split(key)
+    results = ml.train(
+        train_X,
+        train_Y,
+        partial(map_and_loss, net=net, has_aux=has_aux),
+        params,
+        subkey,
+        stop_condition=ml.EpochStop(epochs, verbose=verbose),
+        batch_size=batch_size,
+        optimizer=optax.adamw(
+            optax.warmup_cosine_decay_schedule(1e-8, lr, 5*steps_per_epoch, 50*steps_per_epoch, 1e-7),
+            weight_decay=1e-5,
+        ),
+        validation_X=val_X,
+        validation_Y=val_Y,
+        noise_stdev=noise_stdev,
+        has_aux=has_aux,
+    )
+
+    if has_aux:
+        params, batch_stats, train_loss, val_loss = results
+    else:
+        params, train_loss, val_loss = results
+        batch_stats = None
+
+    if save_params is not None:
+        jnp.save(
+            f'{save_params}{model_name}_L{train_X.get_L()}_e{epochs}_params.npy', 
+            { 'params': params, 'batch_stats': None if (batch_stats is None) else dict(batch_stats) },
+        )
+
+    key, subkey = random.split(key)
+    test_loss = ml.map_loss_in_batches(
+        partial(map_and_loss, net=net, has_aux=has_aux), 
+        params, 
+        test_single_X, 
+        test_single_Y, 
+        batch_size, 
+        subkey, 
+        False,
+        has_aux=has_aux,
+        aux_data=batch_stats,
+    )
+    print(f'Test Loss: {test_loss}')
+
+    key, subkey = random.split(key)
+    test_rollout_loss = ml.map_loss_in_batches(
+        partial(map_and_loss, net=net, has_aux=has_aux, future_steps=5), 
+        params, 
+        test_rollout_X, 
+        test_rollout_Y, 
+        batch_size, 
+        subkey, 
+        False,
+        has_aux=has_aux,
+        aux_data=batch_stats,
+    )
+    print(f'Test Rollout Loss: {test_rollout_loss}')
+
+    return train_loss[-1], val_loss[-1], test_loss, test_rollout_loss
+
+def handleArgs(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filename', help='the directory where the .h5 files are located', type=str)
+    parser.add_argument('-e', '--epochs', help='number of epochs to run', type=int, default=50)
+    parser.add_argument('-lr', help='learning rate', type=float, default=2e-4)
+    parser.add_argument('-batch', help='batch size', type=int, default=16)
+    parser.add_argument('-train_traj', help='number of training trajectories', type=int, default=1)
+    parser.add_argument('-val_traj', help='number of validation trajectories, defaults to 1', type=int, default=1)
+    parser.add_argument('-test_traj', help='number of testing trajectories, defaults to 1', type=int, default=1)
+    parser.add_argument('-seed', help='the random number seed', type=int, default=None)
+    parser.add_argument('-s', '--save', help='file name to save the params', type=str, default=None)
+    parser.add_argument('-l', '--load', help='file name to load params from', type=str, default=None)
+    parser.add_argument(
+        '-images_dir', 
+        help='directory to save images, or None to not save',
+        type=str, 
+        default=None,
+    )
+    parser.add_argument('-subsample', help='how many timesteps per model step, default 1', type=int, default=1)
+    parser.add_argument('-downsample', help='spatial downsampling, number of times to divide by 2', type=int, default=0)
+    parser.add_argument('-t', '--trials', help='number of trials to run', type=int, default=1)
+    parser.add_argument('-v', '--verbose', help='verbose argument passed to trainer', type=int, default=1)
+
+    args = parser.parse_args()
+
+    return (
+        args.filename,
+        args.epochs,
+        args.lr,
+        args.batch,
+        args.train_traj,
+        args.val_traj,
+        args.test_traj,
+        args.seed,
+        args.save,
+        args.load,
+        args.images_dir,
+        args.subsample,
+        args.downsample,
+        args.trials,
+        args.verbose,
+    )
+
+#Main
+(
+    filename, 
+    epochs, 
+    lr, 
+    batch_size, 
+    train_traj, 
+    val_traj, 
+    test_traj, 
+    seed, 
+    save_file, 
+    load_file, 
+    images_dir,
+    subsample,
+    downsample,
+    trials,
+    verbose,
+) = handleArgs(sys.argv)
+
+D = 2
+past_steps = 2 # how many steps to look back to predict the next step
+rollout_steps = 5
+key = random.PRNGKey(time.time_ns()) if (seed is None) else random.PRNGKey(seed)
+
+train_X, train_Y, val_X, val_Y, test_single_X, test_single_Y, test_rollout_X, test_rollout_Y = get_data(
+    filename, 
+    train_traj, 
+    val_traj, 
+    test_traj, 
+    past_steps,
+    rollout_steps,
+    subsample,
+    downsample,
+)
+
+group_actions = geom.make_all_operators(D)
+conv_filters = geom.get_invariant_filters(Ms=[3], ks=[0,1,2], parities=[0,1], D=D, operators=group_actions)
+upsample_filters = geom.get_invariant_filters(Ms=[2], ks=[0,1,2], parities=[0,1], D=D, operators=group_actions)
+
+output_keys = tuple(train_Y.keys())
+train_and_eval = partial(
+    train_and_eval, 
+    lr=lr,
+    batch_size=batch_size, 
+    epochs=epochs, 
+    save_params=save_file, 
+    images_dir=images_dir,
+    verbose=verbose,
+)
+
+models = [
+    (
+        'dil_resnet',
+        partial(
+            train_and_eval, 
+            net=partial(models.dil_resnet, depth=64, activation_f=jax.nn.gelu, output_keys=output_keys),
+        ),
+    ),
+    (
+        'dil_resnet_equiv', # test_loss is better, but rollout is worse
+        partial(
+            train_and_eval, 
+            net=partial(
+                models.dil_resnet, 
+                depth=32, 
+                activation_f=ml.VN_NONLINEAR, # takes more memory, hmm
+                equivariant=True, 
+                conv_filters=conv_filters,
+                output_keys=output_keys,
+            ),
+        ),
+    ),
+    (
+        'do_nothing', 
+        partial(
+            train_and_eval, 
+            net=partial(models.do_nothing, idxs={ (1,0): past_steps-1, (0,0): past_steps-1 }),
+        ),
+    ),
+    # (
+    #     'resnet',
+    #     partial(
+    #         train_and_eval, 
+    #         net=partial(models.resnet, output_keys=output_keys, depth=64),
+    #     ),   
+    # ),
+    # (
+    #     'resnet_equiv', # better across the board
+    #     partial(
+    #         train_and_eval, 
+    #         net=partial(
+    #             models.resnet, 
+    #             output_keys=output_keys, 
+    #             equivariant=True, 
+    #             conv_filters=conv_filters,
+    #             depth=32,
+    #         ),
+    #     ),  
+    # ),
+    # (
+    #     'unet2015',
+    #     partial(
+    #         train_and_eval,
+    #         net=partial(models.unet2015, output_keys=output_keys),
+    #         has_aux=True,
+    #     ),
+    # ),
+    # (
+    #     'unet2015_equiv',
+    #     partial(
+    #         train_and_eval,
+    #         net=partial(
+    #             models.unet2015, 
+    #             equivariant=True,
+    #             conv_filters=conv_filters, 
+    #             upsample_filters=upsample_filters,
+    #             output_keys=output_keys,
+    #             activation_f=ml.VN_NONLINEAR,
+    #             depth=32, # 64=41M, 48=23M, 32=10M
+    #         ),
+    #     ),
+    # ),
+    # (
+    #     'unetBase',
+    #     partial(
+    #         train_and_eval,
+    #         net=partial(
+    #             models.unetBase, 
+    #             output_keys=output_keys, 
+    #         ),
+    #     ),
+    # ),
+    # (
+    #     'unetBase_equiv', # works best
+    #     partial(
+    #         train_and_eval,
+    #         net=partial(
+    #             models.unetBase, 
+    #             output_keys=output_keys,
+    #             equivariant=True,
+    #             conv_filters=conv_filters,
+    #             activation_f=ml.VN_NONLINEAR,
+    #             depth=32,
+    #             upsample_filters=upsample_filters,
+    #         ),
+    #     ),
+    # ),
+]
+
+key, subkey = random.split(key)
+results = ml.benchmark(
+    lambda _, _2: (train_X, train_Y, val_X, val_Y, test_single_X, test_single_Y, test_rollout_X, test_rollout_Y),
+    models,
+    subkey,
+    'Nothing',
+    [0],
+    num_results=4,
+    num_trials=trials,
+)
+
+print(results)

--- a/scripts/shallow_water.py
+++ b/scripts/shallow_water.py
@@ -98,26 +98,34 @@ def get_data_layers(
         # all_vor = (all_vor - normstats['vor']['mean']) / normstats['vor']['std']
         all_vor = all_vor / normstats['vor']['std'] # can only scale to maintain equivariance
 
-    all_uv = all_uv[:num_trajectories,skip_initial::subsample]
-    all_pres = all_pres[:num_trajectories,skip_initial::subsample]
-    all_vor = all_vor[:num_trajectories,skip_initial::subsample]
+    all_uv = all_uv[:num_trajectories]
+    all_pres = all_pres[:num_trajectories]
+    all_vor = all_vor[:num_trajectories]
 
-    input_window_idxs = gc_data.rolling_window_idx(0, all_uv.shape[1]-future_steps, past_steps)
-    input_uv = all_uv[:, input_window_idxs].reshape((-1, past_steps) + spatial_dims + (D,))
-    input_pres = all_pres[:, input_window_idxs].reshape((-1, past_steps) + spatial_dims)
-
-    output_window_idxs = gc_data.rolling_window_idx(past_steps, all_uv.shape[1], future_steps)
-    assert len(output_window_idxs) == len(input_window_idxs)
-    output_uv = all_uv[:, output_window_idxs].reshape((-1, future_steps) + spatial_dims + (D,))
-    output_pres = all_pres[:, output_window_idxs].reshape((-1, future_steps) + spatial_dims)
-    output_vor = all_vor[:, output_window_idxs].reshape((-1, future_steps) + spatial_dims)
-
-    layer_X = geom.BatchLayer({ (0,0): input_pres, (1,0): input_uv }, D, is_torus)
     if pres_vor_form:
-        layer_Y = geom.BatchLayer({ (0,0): output_pres, (0,1): output_vor }, D, is_torus)
+        layer_X, layer_Y = gc_data.times_series_to_layers(
+            D, 
+            { (0,0): all_pres, (0,1): all_vor, (1,0): all_uv }, 
+            {},
+            is_torus, 
+            past_steps, 
+            future_steps,
+            skip_initial,
+            subsample,
+        )
+        del layer_X.data[(0,1)] # remove vorticity from input      
     else:
-        layer_Y = geom.BatchLayer({ (0,0): output_pres, (1,0): output_uv }, D, is_torus)
-
+        layer_X, layer_Y = gc_data.times_series_to_layers(
+            D, 
+            { (0,0): all_pres, (1,0): all_uv }, 
+            {},
+            is_torus, 
+            past_steps, 
+            future_steps,
+            skip_initial,
+            subsample,
+        )
+    
     return layer_X, layer_Y
 
 def get_data(
@@ -196,9 +204,10 @@ def get_data(
 
 def map_and_loss(params, layer_x, layer_y, key, train, aux_data=None, net=None, has_aux=False, future_steps=1):
     assert net is not None
+    pres_vor_form = (0,1) in layer_y.keys()
     curr_layer = layer_x
     out_layer = layer_y.empty()
-    for _ in range(future_steps):
+    for i in range(future_steps):
         key, subkey = random.split(key)
         if has_aux:
             learned_x, aux_data = net(params, curr_layer, subkey, train, batch_stats=aux_data)
@@ -207,10 +216,22 @@ def map_and_loss(params, layer_x, layer_y, key, train, aux_data=None, net=None, 
 
         out_layer = out_layer.concat(learned_x, axis=1)
         next_layer = curr_layer.empty()
-        for (k, parity), img_block in curr_layer.items():
-            next_layer.append(k, parity, jnp.concatenate([img_block[:,1:], learned_x[(k, parity)]], axis=1))
+        if pres_vor_form: 
+            # output is pres/vor, but next step input needs to be pres/velocity, so use the true velocity
+            next_layer.append(0, 0, jnp.concatenate([curr_layer[(0,0)][:,1:], learned_x[(0,0)]], axis=1))
+            next_layer.append(
+                1, 
+                0, 
+                jnp.concatenate([curr_layer[(1,0)][:,1:], layer_y[(1,0)][:,i:i+1]], axis=1),
+            )
+        else:
+            for (k, parity), img_block in curr_layer.items():
+                next_layer.append(k, parity, jnp.concatenate([img_block[:,1:], learned_x[(k, parity)]], axis=1))
 
         curr_layer = next_layer
+
+    if pres_vor_form: # don't include velocity output
+        layer_y = geom.BatchLayer({ (0,0): layer_y[(0,0)], (0,1): layer_y[(0,1)] }, layer_y.D, layer_y.is_torus)
 
     loss = ml.smse_loss(out_layer, layer_y)
     return (loss, aux_data) if has_aux else loss
@@ -287,7 +308,7 @@ def train_and_eval(
 
     key, subkey = random.split(key)
     test_rollout_loss = ml.map_loss_in_batches(
-        partial(map_and_loss, net=net, has_aux=has_aux, future_steps=5), # rollout_steps hardcoded
+        partial(map_and_loss, net=net, has_aux=has_aux, future_steps=5),
         params, 
         test_rollout_X, 
         test_rollout_Y, 
@@ -384,7 +405,7 @@ if test_traj is None:
 if val_traj is None:
     val_traj = batch_size
 
-train_X, train_Y, val_X, val_Y, test_single_X, test_single_Y, test_rollout_X, test_rollout_Y = get_data(
+data = get_data(
     data_dir, 
     train_traj, 
     val_traj, 
@@ -400,7 +421,7 @@ group_actions = geom.make_all_operators(D)
 conv_filters = geom.get_invariant_filters(Ms=[3], ks=[0,1,2], parities=[0,1], D=D, operators=group_actions)
 upsample_filters = geom.get_invariant_filters(Ms=[2], ks=[0,1,2], parities=[0,1], D=D, operators=group_actions)
 
-output_keys = tuple(train_Y.keys())
+output_keys = ((0,0),(0,1)) if pres_vor_form else ((0,0), (1,0))
 train_and_eval = partial(
     train_and_eval, 
     lr=lr,
@@ -501,7 +522,7 @@ models = [
 
 key, subkey = random.split(key)
 results = ml.benchmark(
-    lambda _, _2: (train_X, train_Y, val_X, val_Y, test_single_X, test_single_Y, test_rollout_X, test_rollout_Y),
+    lambda _, _2: data,
     models,
     subkey,
     'Nothing',

--- a/scripts/turb2d.py
+++ b/scripts/turb2d.py
@@ -40,7 +40,13 @@ def read_one_h5(filename: str, data_class: str) -> tuple:
 
     return u, vxy
 
-def merge_h5s_into_layer(data_dir: str, num_trajectories: int, data_class: str, window: int) -> tuple:
+def merge_h5s_into_layer(
+    data_dir: str, 
+    num_trajectories: int, 
+    data_class: str, 
+    past_steps: int,
+    future_steps: int,
+) -> tuple:
     """
     Given a specified dataset, load the data into layers where the layer_X has a channel per image in the
     lookback window, and the layer_Y has just the single next image.
@@ -48,12 +54,14 @@ def merge_h5s_into_layer(data_dir: str, num_trajectories: int, data_class: str, 
         data_dir (str): directory of the data
         seeds (list of str): seeds for the data
         data_class (str): type of data, either train, valid, or test
-        window (int): the lookback window, how many steps we look back to predict the next one
+        past_steps (int): the lookback window, how many steps we look back to predict the next one
+        future_steps (int): the number of future steps to predict
     """
     all_files = sorted(filter(lambda file: f'NavierStokes2D_{data_class}' in file, os.listdir(data_dir)))
 
     N = 128
     D = 2
+    spatial_dims = (N,)*D
     all_u = jnp.zeros((0,14,N,N))
     all_vxy = jnp.zeros((0,14,N,N,D))
     for filename in all_files:
@@ -72,20 +80,31 @@ def merge_h5s_into_layer(data_dir: str, num_trajectories: int, data_class: str, 
         )
         num_trajectories = len(all_u)
 
-    # all_u.shape[1] -1 because the last one is the output
-    window_idx = gc_data.rolling_window_idx(all_u.shape[1]-1, window)
-    input_u = all_u[:num_trajectories, window_idx].reshape((-1, window, N, N))
-    input_vxy = all_vxy[:num_trajectories, window_idx].reshape((-1, window, N, N, D))
+    all_u = all_u[:num_trajectories]
+    all_vxy = all_vxy[:num_trajectories]
 
-    output_u = all_u[:num_trajectories, window:].reshape(-1, 1, N, N)
-    output_vxy = all_vxy[:num_trajectories, window:].reshape(-1, 1, N, N, D)
+    input_window_idxs = gc_data.rolling_window_idx(0, all_u.shape[1]-future_steps, past_steps)
+    input_u = all_u[:, input_window_idxs].reshape((-1, past_steps) + spatial_dims)
+    input_vxy = all_vxy[:, input_window_idxs].reshape((-1, past_steps) + spatial_dims + (D,))
+
+    output_window_idxs = gc_data.rolling_window_idx(past_steps, all_u.shape[1], future_steps)
+    assert len(output_window_idxs) == len(input_window_idxs)
+    output_u = all_u[:, output_window_idxs].reshape((-1, future_steps) + spatial_dims)
+    output_vxy = all_vxy[:, output_window_idxs].reshape((-1, future_steps) + spatial_dims + (D,))
 
     layer_X = geom.BatchLayer({ (0,0): input_u, (1,0): input_vxy }, D, False)
     layer_Y = geom.BatchLayer({ (0,0): output_u, (1,0): output_vxy }, D, False)
 
     return layer_X, layer_Y
 
-def get_data(data_dir: str, num_train_traj: int, num_val_traj: int, num_test_traj: int, window: int) -> tuple:
+def get_data(
+    data_dir: str, 
+    num_train_traj: int, 
+    num_val_traj: int, 
+    num_test_traj: int, 
+    past_steps: int,
+    future_steps: int,
+) -> tuple:
     """
     Get train, val, and test data sets.
     args:
@@ -93,11 +112,12 @@ def get_data(data_dir: str, num_train_traj: int, num_val_traj: int, num_test_tra
         num_train_traj (int): number of training trajectories
         num_val_traj (int): number of validation trajectories
         num_test_traj (int): number of testing trajectories
-        window (int): length of the lookback to predict the next step
+        past_steps (int): length of the lookback to predict the next step
+        future_steps (int): the number of future steps to predict
     """
-    train_X, train_Y = merge_h5s_into_layer(data_dir, num_train_traj, 'train', window)
-    val_X, val_Y = merge_h5s_into_layer(data_dir, num_val_traj, 'valid', window)
-    test_X, test_Y = merge_h5s_into_layer(data_dir, num_test_traj, 'test', window)
+    train_X, train_Y = merge_h5s_into_layer(data_dir, num_train_traj, 'train', past_steps, future_steps)
+    val_X, val_Y = merge_h5s_into_layer(data_dir, num_val_traj, 'valid', past_steps, future_steps)
+    test_X, test_Y = merge_h5s_into_layer(data_dir, num_test_traj, 'test', past_steps, future_steps)
 
     return train_X, train_Y, val_X, val_Y, test_X, test_Y
 
@@ -147,6 +167,7 @@ def train_and_eval(
     images_dir, 
     noise_stdev=None,
     has_aux=False,
+    verbose=1,
 ):
     train_X, train_Y, val_X, val_Y, test_X, test_Y = data
 
@@ -156,7 +177,7 @@ def train_and_eval(
         train_X.get_one(),
         subkey,
     )
-    print(f'Model params: {ml.count_params(params)}')
+    print(f'Model params: {ml.count_params(params):,}')
 
     steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
 
@@ -167,7 +188,7 @@ def train_and_eval(
         partial(map_and_loss, net=net, has_aux=has_aux),
         params,
         subkey,
-        stop_condition=ml.EpochStop(epochs, verbose=2),
+        stop_condition=ml.EpochStop(epochs, verbose=verbose),
         batch_size=batch_size,
         optimizer=optax.adamw(
             optax.warmup_cosine_decay_schedule(1e-8, lr, 5*steps_per_epoch, epochs*steps_per_epoch, 1e-7),
@@ -251,6 +272,7 @@ def handleArgs(argv):
         type=str, 
         default=None,
     )
+    parser.add_argument('-v', '--verbose', help='verbose argument passed to trainer', type=int, default=1)
 
     args = parser.parse_args()
 
@@ -266,15 +288,17 @@ def handleArgs(argv):
         args.save,
         args.load,
         args.images_dir,
+        args.verbose,
     )
 
 #Main
 args = handleArgs(sys.argv)
-data_dir, epochs, lr, batch_size, train_traj, val_traj, test_traj, seed, save_file, load_file, images_dir = args
+data_dir, epochs, lr, batch_size, train_traj, val_traj, test_traj, seed, save_file, load_file, images_dir, verbose = args
 
 D = 2
 N = 128
-window = 4 # how many steps to look back to predict the next step
+past_steps = 4 # how many steps to look back to predict the next step
+future_steps = 1
 key = random.PRNGKey(time.time_ns()) if (seed is None) else random.PRNGKey(seed)
 
 # an attempt to reduce recompilation, but I don't think it actually is working
@@ -283,12 +307,13 @@ if test_traj is None:
 if val_traj is None:
     val_traj = batch_size
 
-train_X, train_Y, val_X, val_Y, test_X, test_Y = get_data(data_dir, train_traj, val_traj, test_traj, window)
+train_X, train_Y, val_X, val_Y, test_X, test_Y = get_data(data_dir, train_traj, val_traj, test_traj, past_steps, future_steps)
 
 group_actions = geom.make_all_operators(D)
 conv_filters = geom.get_invariant_filters(Ms=[3], ks=[0,1,2], parities=[0,1], D=D, operators=group_actions)
 upsample_filters = geom.get_invariant_filters(Ms=[2], ks=[0,1,2], parities=[0,1], D=D, operators=group_actions)
 
+output_keys = tuple(train_Y.keys())
 train_and_eval = partial(
     train_and_eval, 
     lr=lr,
@@ -296,6 +321,7 @@ train_and_eval = partial(
     epochs=epochs, 
     save_params=save_file, 
     images_dir=images_dir,
+    verbose=verbose,
 )
 
 models = [
@@ -317,7 +343,7 @@ models = [
         'unet2015',
         partial(
             train_and_eval,
-            net=models.unet2015,
+            net=partial(models.unet2015, output_keys=output_keys),
             has_aux=True,
         ),
     ),
@@ -326,9 +352,12 @@ models = [
         partial(
             train_and_eval,
             net=partial(
-                models.unet2015_equiv, 
+                models.unet2015, 
                 conv_filters=conv_filters, 
                 upsample_filters=upsample_filters,
+                equivariant=True,
+                output_keys=output_keys,
+                activation_f=ml.VN_NONLINEAR,
                 depth=32, # 64=41M, 48=23M, 32=10M
             ),
         ),

--- a/src/geometricconvolutions/data.py
+++ b/src/geometricconvolutions/data.py
@@ -10,6 +10,7 @@ import jax.nn
 
 import geometricconvolutions.geometric as geom
 import geometricconvolutions.utils as utils
+import geometricconvolutions.ml as ml
 
 # ------------------------------------------------------------------------------
 # Data generation functions
@@ -136,6 +137,66 @@ def get_charge_data(N, D, num_charges, num_steps, delta_t, s, rand_key, num_imag
 
     return geom.BatchLayer.from_images(initial_fields), geom.BatchLayer.from_images(final_fields)
 
+# ------------------------------------------------------------------------------
+# Functions for parsing time series data
+
 # from: https://github.com/google/jax/issues/3171
 def rolling_window_idx(start: int, end: int, window: int) -> jnp.ndarray:
   return jnp.arange(start, end - window + 1)[:, None] + jnp.arange(window)[None, :]
+
+def times_series_to_layers(
+    D: int,
+    dynamic_fields: dict,
+    constant_fields: dict,
+    is_torus,
+    past_steps: int,
+    future_steps: int,
+    skip_initial: int = 0, 
+    subsample: int = 1,
+    downsample: int = 0,
+) -> tuple:
+    """
+    Given time series fields, convert them to input and output BatchLayers based on the number of past steps,
+    future steps, and any subsampling/downsampling.
+    args:
+        dynamic_fields (dict of jnp.array): the fields to build layers, dict with keys (k,parity) and values
+            of array of shape (batch,time,spatial,tensor)
+        constant_fields (dict of jnp.array): fields constant over time, dict with keys (k,parity) and values
+            of array of shape (batch,spatial,tensor)
+        force (jnp.array): vector field, constant forcing term, shape (batch,spatial,D)
+        particles (jnp.array): scalar field, advected particle density (batch,time,spatial,D)
+        velocity (jnp.array): vector field, velocity of the fluid (batch,time,spatial,D)
+        past_steps (int): number of historical steps to use in the model
+        future_steps (int): number of future steps
+        skip_intial (int): number of initial time steps to skip, defaults to 0
+        subsample (int): subsample the time dimension, defaults to 1 which is no subsampling
+        downsample (int): number of times to downsample the image by average pooling, decreases by a factor
+            of 2, defaults to 0 times.
+    returns tuple of BatchLayers layer_X and layer_Y
+    """
+    assert len(dynamic_fields.values()) != 0
+
+    subsampled_fields = { k: v[:,skip_initial::subsample] for k,v in dynamic_fields.items() }
+    t_steps = next(iter(subsampled_fields.values())).shape[1] # time steps, also total steps
+    # add a time dimension to force and fill it with copies
+    constant_fields = { k: jnp.full((len(v),t_steps) + v.shape[1:], v[:,None]) for k,v in constant_fields.items() }
+
+    input_idxs = rolling_window_idx(0, t_steps-future_steps, past_steps)
+    input_dynamic_fields = { k: v[:, input_idxs].reshape((-1,past_steps) + v.shape[2:]) for k,v in subsampled_fields.items() }
+    input_constant_fields = { k: v[:, input_idxs].reshape((-1,past_steps) + v.shape[2:])[:,:1] for k,v in constant_fields.items() }
+
+    output_idxs = rolling_window_idx(past_steps, t_steps, future_steps)
+    assert len(input_idxs) == len(output_idxs)
+    output_dynamic_fields = { k: v[:, output_idxs].reshape((-1,future_steps) + v.shape[2:]) for k,v in subsampled_fields.items() }
+
+    layer_X = geom.BatchLayer(input_dynamic_fields, D, is_torus).concat(
+        geom.BatchLayer(input_constant_fields, D, is_torus),
+        axis=1,
+    )
+    layer_Y = geom.BatchLayer(output_dynamic_fields, D, is_torus)
+
+    for _ in range(downsample):
+        layer_X = ml.batch_average_pool(layer_X, 2)
+        layer_Y = ml.batch_average_pool(layer_Y, 2)
+
+    return layer_X, layer_Y

--- a/src/geometricconvolutions/models.py
+++ b/src/geometricconvolutions/models.py
@@ -27,7 +27,7 @@ def unet_conv_block(
         conv_kwargs (dict): keyword args to pass the the convolution function
         batch_stats (dict): state for batch_norm, also determines whether batch_norm layer happens
         batch_stats_idx (int): the index of batch_norm that we are on
-        activaton_f (function): the function that we pass to batch_scalar_activation
+        activation_f (string or function): the function that we pass to batch_scalar_activation
         mold_params (bool): whether we are mapping the params, or applying them
     returns: layer, params, batch_stats, batch_stats_idx 
     """
@@ -101,7 +101,7 @@ def unetBase(
             experiments, should be ((0,0),(1,0)) for the pressure/velocity form and ((0,0),(0,1)) for 
             the pressure/vorticity form.
         depth (int): the depth of the layers, defaults to 64
-        activaton_f (function): the function that we pass to batch_scalar_activation
+        activation_f (string or function): the function that we pass to batch_scalar_activation
         equivariant (bool): whether to use the equivariant version of the model, defaults to False
         conv_filters (Layer): the conv filters used for the equivariant version
         upsample_filters (Layer): the conv filters used for the upsample layer of the equivariant version
@@ -467,7 +467,7 @@ def resnet(
         key (jnp.random key): key for any layers requiring randomization
         train (bool): whether train mode or test mode, relevant for batch_norm
         depth (int): the depth of the layers, defaults to 48
-        activaton_f (function): the function that we pass to batch_scalar_activation, defaults to relu
+        activation_f (string or function): the function that we pass to batch_scalar_activation, defaults to relu
         equivariant (bool): whether to use the equivariant version of the model, defaults to False
         conv_filters (Layer): the conv filters used for the equivariant version
         return_params (bool): whether we are mapping the params, or applying them

--- a/src/geometricconvolutions/models.py
+++ b/src/geometricconvolutions/models.py
@@ -1,7 +1,6 @@
 import functools
 from collections import defaultdict
 
-import jax.numpy as jnp
 import jax
 
 import geometricconvolutions.geometric as geom
@@ -50,10 +49,26 @@ def unet_conv_block(
             )
             batch_stats[batch_stats_idx] = { 'mean': mean, 'var': var }
             batch_stats_idx += 1
-        if activation_f is not None:
-            layer = ml.batch_scalar_activation(layer, activation_f)
+        layer, params = handle_activation(activation_f, params, layer, mold_params)
 
     return layer, params, batch_stats, batch_stats_idx
+
+ACTIVATION_REGISTRY = {
+    'relu': jax.nn.relu,
+    'gelu': jax.nn.gelu,
+    'tanh': jax.nn.tanh,
+}
+
+def handle_activation(activation_f, params, layer, mold_params):
+    if activation_f is None:
+        return layer, params
+    elif isinstance(activation_f, str):
+        if activation_f == ml.VN_NONLINEAR:
+            return ml.VN_nonlinear(params, layer, mold_params=mold_params)
+        else:
+            return ml.batch_scalar_activation(layer, ACTIVATION_REGISTRY[activation_f]), params
+    else:
+        return ml.batch_scalar_activation(layer, activation_f), params
 
 @functools.partial(jax.jit, static_argnums=[3,4,5,6,7,10])
 def unetBase(
@@ -67,6 +82,7 @@ def unetBase(
     equivariant=False,
     conv_filters=None, 
     upsample_filters=None, # 2x2 filters
+    use_group_norm=True,
     return_params=False,
 ):
     """
@@ -89,6 +105,7 @@ def unetBase(
         equivariant (bool): whether to use the equivariant version of the model, defaults to False
         conv_filters (Layer): the conv filters used for the equivariant version
         upsample_filters (Layer): the conv filters used for the upsample layer of the equivariant version
+        use_group_norm (bool): whether to use group_norm, defaults to True
         return_params (bool): whether we are mapping the params, or applying them
     """
     num_downsamples = 4
@@ -101,12 +118,10 @@ def unetBase(
         filter_info = { 'type': ml.CONV_FIXED, 'filters': conv_filters }
         filter_info_upsample = { 'type': ml.CONV_FIXED, 'filters': upsample_filters }
         target_keys = output_keys
-        use_group_norm = True
     else:
         filter_info = { 'type': ml.CONV_FREE, 'M': 3 }
         filter_info_upsample = { 'type': ml.CONV_FREE, 'M': 2 }
         target_keys = ((0,0),)
-        use_group_norm = True
 
         # convert to channels of a scalar layer
         layer = layer.to_scalar_layer()
@@ -124,8 +139,7 @@ def unetBase(
         )
         if use_group_norm:
             layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=return_params)
-        if activation_f is not None:
-            layer = ml.batch_scalar_activation(layer, activation_f)
+        layer, params = handle_activation(activation_f, params, layer, return_params)
 
     # first we do the downsampling
     residual_layers = []
@@ -147,8 +161,7 @@ def unetBase(
             )
             if use_group_norm:
                 layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=return_params)
-            if activation_f is not None:
-                layer = ml.batch_scalar_activation(layer, activation_f)
+            layer, params = handle_activation(activation_f, params, layer, return_params)
 
     # now we do the upsampling and concatenation
     for upsample in reversed(range(num_downsamples)):
@@ -180,8 +193,7 @@ def unetBase(
             )
             if use_group_norm:
                 layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=return_params)
-            if activation_f is not None:
-                layer = ml.batch_scalar_activation(layer, activation_f)
+            layer, params = handle_activation(activation_f, params, layer, return_params)
 
     layer, params = ml.batch_conv_layer(
         params,
@@ -332,7 +344,7 @@ def unet2015(
 
     return res
 
-@functools.partial(jax.jit, static_argnums=[3,4,5,6,8])
+@functools.partial(jax.jit, static_argnums=[3,4,5,6,7,9])
 def dil_resnet(
     params, 
     layer, 
@@ -343,6 +355,7 @@ def dil_resnet(
     activation_f=jax.nn.relu, 
     equivariant=False, 
     conv_filters=None, 
+    use_group_norm=False,
     return_params=False,
 ):
     """
@@ -356,7 +369,7 @@ def dil_resnet(
         key (jnp.random key): key for any layers requiring randomization
         train (bool): whether train mode or test mode, relevant for batch_norm
         depth (int): the depth of the layers, defaults to 48
-        activaton_f (function): the function that we pass to batch_scalar_activation, defaults to relu
+        activation_f (string or function): the function that we pass to batch_scalar_activation, defaults to relu
         equivariant (bool): whether to use the equivariant version of the model, defaults to False
         conv_filters (Layer): the conv filters used for the equivariant version
         return_params (bool): whether we are mapping the params, or applying them
@@ -386,8 +399,7 @@ def dil_resnet(
             bias=True,
             mold_params=return_params,
         )
-        if activation_f is not None:
-            layer = ml.batch_scalar_activation(layer, activation_f)
+        layer, params = handle_activation(activation_f, params, layer, return_params)
 
     for _ in range(num_blocks):
 
@@ -404,8 +416,9 @@ def dil_resnet(
                 mold_params=return_params,
                 rhs_dilation=(dilation,)*layer.D,
             )
-            if activation_f is not None:
-                layer = ml.batch_scalar_activation(layer, activation_f)
+            if use_group_norm:
+                layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=return_params)
+            layer, params = handle_activation(activation_f, params, layer, return_params)
 
         layer = geom.BatchLayer.from_vector(layer.to_vector() + residual_layer.to_vector(), layer)
 
@@ -419,8 +432,7 @@ def dil_resnet(
         bias=True,
         mold_params=return_params,
     )
-    if activation_f is not None:
-        layer = ml.batch_scalar_activation(layer, activation_f)
+    layer, params = handle_activation(activation_f, params, layer, return_params)
     layer, params = ml.batch_conv_layer(
         params, 
         layer,
@@ -485,8 +497,7 @@ def resnet(
             bias=True,
             mold_params=return_params,
         )
-        if activation_f is not None:
-            layer = ml.batch_scalar_activation(layer, activation_f)
+        layer, params = handle_activation(activation_f, params, layer, return_params)
 
     for _ in range(num_blocks):
 
@@ -495,8 +506,7 @@ def resnet(
         for _ in range(num_conv):
             # pre-activation order
             layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=return_params)
-            if activation_f is not None:
-                layer = ml.batch_scalar_activation(layer, activation_f)
+            layer, params = handle_activation(activation_f, params, layer, return_params)
 
             layer, params = ml.batch_conv_layer(
                 params, 
@@ -520,8 +530,7 @@ def resnet(
         bias=True,
         mold_params=return_params,
     )
-    if activation_f is not None:
-        layer = ml.batch_scalar_activation(layer, activation_f)
+    layer, params = handle_activation(activation_f, params, layer, return_params)
     
     layer, params = ml.batch_conv_layer(
         params, 
@@ -534,3 +543,22 @@ def resnet(
     )
 
     return (layer, params) if return_params else layer
+
+def do_nothing(params, layer, key, train, idxs, return_params=False):
+    """
+    Not to be confused with Calvin Coolidge. Allows you to compare the loss to a model that just picks one 
+    channel of each layer as the output. This is helpful for dynamics problems where sometimes just picking
+    the next step as the previous step is a surprisingly effective strategy.
+    args:
+        params (dict): the params tree
+        layer (BatchLayer): input layer
+        key (rand_key):
+        train (bool): whether we are train mode
+        idxs (dict): dict of (k,parity): idx where idx is layer to select as the output
+    """
+    out_layer = layer.empty()
+    for (k, parity), image_block in layer.items():
+        idx = idxs[(k,parity)]
+        out_layer.append(k, parity, image_block[:,idx:idx+1])
+
+    return (out_layer, params) if return_params else out_layer


### PR DESCRIPTION
## Changes
- add script ns_incomp_2d for the pdebench ns data
- add gc_data function `time_series_to_layers` the handle the task of splitting time series data in input and output data layers with a specified number of historical, future steps
- fix shallow water to do rollouts with pres_vor_form correctly
- update turb2d with some modern features
- add vector_dots_nonlinear function for another nonlineaerity strategy based on scalars are universal. It doesn't seem to work that well, and uses a lot of parameters
- start moving losses to handle layers
- update models to be more flexible in regard to activation functions
- add a model that does nothing, just returns the last channel to help with benchmarking
- change the batcher so that remainder terms are ignored. This is to avoid issues splitting over multiple gpus and it being uneven.

## Testing
- shallow water script with pres_vor_form and not
- turb2d
- ns_incomp_2d

## Doc Changes
- none