### PR TITLE
update dataloading to be more efficient for large turbulence sims

### DIFF
--- a/scripts/ns_incomp_2d.py
+++ b/scripts/ns_incomp_2d.py
@@ -279,7 +279,6 @@ def train_and_eval(
     steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
 
     if load_params is None:
-        print('in here')
         key, subkey = random.split(key)
         results = ml.train(
             train_X,
@@ -485,79 +484,79 @@ train_and_eval = partial(
 )
 
 models = [
-    # (
-    #     'do_nothing', 
-    #     partial(
-    #         train_and_eval, 
-    #         net=partial(models.do_nothing, idxs={ (1,0): past_steps-1, (0,0): past_steps-1 }),
-    #     ),
-    # ),
-    # (
-    #     'dil_resnet',
-    #     partial(
-    #         train_and_eval, 
-    #         net=partial(models.dil_resnet, depth=64, activation_f=jax.nn.gelu, output_keys=output_keys),
-    #     ),
-    # ),
-    # (
-    #     'dil_resnet_equiv', # test_loss is better, but rollout is worse
-    #     partial(
-    #         train_and_eval, 
-    #         net=partial(
-    #             models.dil_resnet, 
-    #             depth=32, 
-    #             activation_f=ml.VN_NONLINEAR, # takes more memory, hmm
-    #             equivariant=True, 
-    #             conv_filters=conv_filters,
-    #             output_keys=output_keys,
-    #         ),
-    #     ),
-    # ),
-    # (
-    #     'resnet',
-    #     partial(
-    #         train_and_eval, 
-    #         net=partial(models.resnet, output_keys=output_keys, depth=64),
-    #     ),   
-    # ),
-    # (
-    #     'resnet_equiv', 
-    #     partial(
-    #         train_and_eval, 
-    #         net=partial(
-    #             models.resnet, 
-    #             output_keys=output_keys, 
-    #             equivariant=True, 
-    #             conv_filters=conv_filters,
-    #             activation_f=ml.VN_NONLINEAR,
-    #             use_group_norm=False,
-    #             depth=32,
-    #         ),
-    #     ),  
-    # ),
-    # (
-    #     'unet2015',
-    #     partial(
-    #         train_and_eval,
-    #         net=partial(models.unet2015, output_keys=output_keys),
-    #         has_aux=True,
-    #     ),
-    # ),
-    # (
-    #     'unet2015_equiv',
-    #     partial(
-    #         train_and_eval,
-    #         net=partial(
-    #             models.unet2015, 
-    #             equivariant=True,
-    #             conv_filters=conv_filters, 
-    #             upsample_filters=upsample_filters,
-    #             output_keys=output_keys,
-    #             activation_f=ml.VN_NONLINEAR,
-    #             depth=32, # 64=41M, 48=23M, 32=10M
-    #         ),
-    #     ),
-    # ),
+    (
+        'do_nothing', 
+        partial(
+            train_and_eval, 
+            net=partial(models.do_nothing, idxs={ (1,0): past_steps-1, (0,0): past_steps-1 }),
+        ),
+    ),
+    (
+        'dil_resnet',
+        partial(
+            train_and_eval, 
+            net=partial(models.dil_resnet, depth=64, activation_f=jax.nn.gelu, output_keys=output_keys),
+        ),
+    ),
+    (
+        'dil_resnet_equiv', # test_loss is better, but rollout is worse
+        partial(
+            train_and_eval, 
+            net=partial(
+                models.dil_resnet, 
+                depth=32, 
+                activation_f=ml.VN_NONLINEAR, # takes more memory, hmm
+                equivariant=True, 
+                conv_filters=conv_filters,
+                output_keys=output_keys,
+            ),
+        ),
+    ),
+    (
+        'resnet',
+        partial(
+            train_and_eval, 
+            net=partial(models.resnet, output_keys=output_keys, depth=64),
+        ),   
+    ),
+    (
+        'resnet_equiv', 
+        partial(
+            train_and_eval, 
+            net=partial(
+                models.resnet, 
+                output_keys=output_keys, 
+                equivariant=True, 
+                conv_filters=conv_filters,
+                activation_f=ml.VN_NONLINEAR,
+                use_group_norm=False,
+                depth=32,
+            ),
+        ),  
+    ),
+    (
+        'unet2015',
+        partial(
+            train_and_eval,
+            net=partial(models.unet2015, output_keys=output_keys),
+            has_aux=True,
+        ),
+    ),
+    (
+        'unet2015_equiv',
+        partial(
+            train_and_eval,
+            net=partial(
+                models.unet2015, 
+                equivariant=True,
+                conv_filters=conv_filters, 
+                upsample_filters=upsample_filters,
+                output_keys=output_keys,
+                activation_f=ml.VN_NONLINEAR,
+                depth=32, # 64=41M, 48=23M, 32=10M
+            ),
+        ),
+    ),
     (
         'unetBase',
         partial(

--- a/src/geometricconvolutions/utils.py
+++ b/src/geometricconvolutions/utils.py
@@ -327,7 +327,7 @@ def setup_image_plot():
     ff = plt.figure(figsize=(8, 6))
     return ff
 
-def plot_scalar_image(image, vmin=-1., vmax=1., ax=None, colorbar=False, title=''):
+def plot_scalar_image(image, vmin=-1., vmax=1., ax=None, colorbar=False, boxes=False, title=''):
     assert image.D == 2
     assert image.k == 0
     assert image.spatial_dims == (image.spatial_dims[0],)*image.D, 'Can only' \
@@ -343,7 +343,7 @@ def plot_scalar_image(image, vmin=-1., vmax=1., ax=None, colorbar=False, title='
     if vmax is None:
         vmax = np.percentile(plotdata[:, 2], 97.5)
     plot_scalars(ax, image.spatial_dims[0], plotdata[:, 0], plotdata[:, 1], plotdata[:, 2],
-                 symbols=False, vmin=vmin, vmax=vmax, colorbar=colorbar)
+                 symbols=False, boxes=boxes, vmin=vmin, vmax=vmax, colorbar=colorbar)
     image_axis(ax, plotdata, title)
     return ax
 


### PR DESCRIPTION
## Changes
- in the ns_incomp_2d script that uses pdebench data, downsample the resolution before splitting it, and save those downsampled versions in new files
- allow loading params 
- default to no boxes when plotting images (not filters)

## Testing
- run the ns_incomp script

## Doc Changes
- none