### PR TITLE
update turb2d, swap add to do add instead of concat

### DIFF
--- a/scripts/gravity_benchmark.py
+++ b/scripts/gravity_benchmark.py
@@ -41,7 +41,7 @@ def batch_net(params, layer, key, train, conv_filters, return_params=False):
     spatial_dims = layer.get_spatial_dims()
 
     batch_conv_layer = vmap(ml.conv_layer, in_axes=((None,)*2 + (0,) + (None,)*7), out_axes=(0,None))
-    batch_add_layer = vmap(lambda layer_a, layer_b: layer_a + layer_b) #better way of doing this?
+    batch_concat_layer = vmap(lambda layer_a, layer_b: layer_a.concat(layer_b)) #better way of doing this?
 
     layer, params = batch_conv_layer(params, conv_filters, layer, None, None, return_params, None, None, None, None)
     out_layer = layer.empty()
@@ -58,7 +58,7 @@ def batch_net(params, layer, key, train, conv_filters, return_params=False):
             None,
             (dilation,)*D, #rhs_dilation
         )
-        out_layer = batch_add_layer(out_layer, dilation_out_layer)
+        out_layer = batch_concat_layer(out_layer, dilation_out_layer)
 
     layer = out_layer
 
@@ -76,7 +76,7 @@ def batch_net(params, layer, key, train, conv_filters, return_params=False):
             None,
             (dilation,)*D, #rhs_dilation
         )
-        out_layer = batch_add_layer(out_layer, dilation_out_layer)
+        out_layer = batch_concat_layer(out_layer, dilation_out_layer)
 
     layer = out_layer
     layer = ml.batch_all_contractions(target_k, layer)
@@ -92,7 +92,7 @@ def baseline_net(params, layer, key, train, return_params=False):
     out_channels = 2
     spatial_dims = layer.get_spatial_dims()
 
-    batch_add_layer = vmap(lambda layer_a, layer_b: layer_a + layer_b)
+    batch_concat_layer = vmap(lambda layer_a, layer_b: layer_a.concat(layer_b))
 
     layer, params = ml.batch_conv_layer(
         params,
@@ -112,7 +112,7 @@ def baseline_net(params, layer, key, train, return_params=False):
             mold_params=return_params,
             rhs_dilation=(dilation,)*D,
         )
-        out_layer = batch_add_layer(out_layer, dilation_out_layer)
+        out_layer = batch_concat_layer(out_layer, dilation_out_layer)
 
     layer = out_layer
 
@@ -133,7 +133,7 @@ def baseline_net(params, layer, key, train, return_params=False):
             dilation_out_layer.D,
             dilation_out_layer.is_torus,
         )
-        out_layer = batch_add_layer(out_layer, reshaped_layer)
+        out_layer = batch_concat_layer(out_layer, reshaped_layer)
 
     layer, params = ml.batch_channel_collapse(params, out_layer, mold_params=return_params)
     return (layer, params) if return_params else layer

--- a/scripts/gravity_field.py
+++ b/scripts/gravity_field.py
@@ -47,7 +47,7 @@ def batch_net(params, layer, key, train, conv_filters, return_params=False):
     spatial_dims = layer.get_spatial_dims()
 
     batch_conv_layer = jax.vmap(ml.conv_layer, in_axes=((None,)*2 + (0,) + (None,)*7), out_axes=(0,None))
-    batch_add_layer = jax.vmap(lambda layer_a, layer_b: layer_a + layer_b) #better way of doing this?
+    batch_concat_layer = jax.vmap(lambda layer_a, layer_b: layer_a.concat(layer_b)) #better way of doing this?
 
     layer, params = batch_conv_layer(params, conv_filters, layer, None, None, return_params, None, None, None, None)
     out_layer = layer.empty()
@@ -64,7 +64,7 @@ def batch_net(params, layer, key, train, conv_filters, return_params=False):
             None,
             (dilation,)*D, #rhs_dilation
         )
-        out_layer = batch_add_layer(out_layer, dilation_out_layer)
+        out_layer = batch_concat_layer(out_layer, dilation_out_layer)
 
     layer = out_layer
 

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -42,9 +42,9 @@ def permutation_matrix_from_sequence(seq):
         row = [0]*D
         row[num] = 1
         permutation_matrix.append(row)
-    return jnp.array(permutation_matrix)
+    return np.array(permutation_matrix)
 
-def make_all_operators(D):
+def make_all_operators(D, with_inverses=False):
     """
     Construct all operators of dimension D that are rotations of 90 degrees, or reflections, or a combination of the
     two. This is equivalent to all the permutation matrices where each entry can either be +1 or -1
@@ -58,7 +58,9 @@ def make_all_operators(D):
     possible_entries = [np.diag(prod) for prod in it.product([1,-1], repeat=D)]
 
     #combine all the permutation matrices with the possible entries, then flatten to a single array of operators
-    return list(it.chain(*list(map(lambda matrix: [matrix @ prod for prod in possible_entries], permutation_matrices))))
+    operators = list(it.chain(*list(map(lambda matrix: [matrix @ prod for prod in possible_entries], permutation_matrices))))
+
+    return [(gg, gg.T) for gg in operators] if with_inverses else operators
 
 # ------------------------------------------------------------------------------
 # PART 2: Define the Kronecker Delta and Levi Civita symbols to be used in Levi Civita contractions
@@ -847,21 +849,22 @@ def get_rotated_keys(D, data, gg):
         Get the rotated keys of data when it will be rotated by gg. Note that we rotate the key vector indices
         by the inverse of gg per the definition (this is done by key_array @ gg, rather than gg @ key_array).
         When the spatial_dims are not square, this gets a little tricky.
+        The gg needs to be a concrete (numpy) array, not a traced jax array.
         args:
             D (int): dimension of image
             data (jnp.array): data array to be rotated
             gg (jnp array-like): group operation
         """
         spatial_dims, _ = parse_shape(data.shape, D)
-        rotated_spatial_dims = tuple(jnp.abs(gg @ jnp.array(spatial_dims)))
+        rotated_spatial_dims = tuple(np.abs(gg @ np.array(spatial_dims)))
 
         # When spatial_dims is nonsquare, we have to subtract one version, then add the rotated version.
-        centering_coords = (jnp.array(rotated_spatial_dims).reshape((1,D)) - 1) / 2
-        rotated_centering_coords = jnp.abs(gg @ centering_coords.reshape((D,1))).reshape((1,D))
+        centering_coords = (np.array(rotated_spatial_dims).reshape((1,D)) - 1) / 2
+        rotated_centering_coords = np.abs(gg @ centering_coords.reshape((D,1))).reshape((1,D))
         # rotated keys will need to have the rotated_spatial_dims numbers
-        key_array = jnp.array([key for key in it.product(*list(range(N) for N in rotated_spatial_dims))])
+        key_array = np.array([key for key in it.product(*list(range(N) for N in rotated_spatial_dims))])
         shifted_key_array = key_array - centering_coords
-        return jnp.rint((shifted_key_array @ gg) + rotated_centering_coords).astype(int)
+        return np.rint((shifted_key_array @ gg) + rotated_centering_coords).astype(int)
 
 def times_group_element(D, data, parity, gg, precision=None):
         """
@@ -880,7 +883,7 @@ def times_group_element(D, data, parity, gg, precision=None):
         sign, _ = jnp.linalg.slogdet(gg)
         parity_flip = sign ** parity #if parity=1, the flip operators don't flip the tensors
 
-        rotated_spatial_dims = tuple(jnp.abs(gg @ jnp.array(spatial_dims)))
+        rotated_spatial_dims = tuple(np.abs(gg @ np.array(spatial_dims)))
         rotated_keys = get_rotated_keys(D, data, gg)
         rotated_pixels = data[hash(D, data, rotated_keys)].reshape(rotated_spatial_dims + (D,)*k)
 
@@ -1611,7 +1614,7 @@ class Layer:
 
     def __add__(self, other):
         """
-        Addition operator for Layers, merges them together
+        Addition operator for Layers, must have the same types of layers, adds them together
         """
         assert type(self) == type(other), \
             f'{self.__class__}::__add__: Types of layers being added must match, had {type(self)} and {type(other)}'
@@ -1619,12 +1622,25 @@ class Layer:
             f'{self.__class__}::__add__: Dimension of layers must match, had {self.D} and {other.D}'
         assert self.is_torus == other.is_torus, \
             f'{self.__class__}::__add__: is_torus of layers must match, had {self.is_torus} and {other.is_torus}'
+        assert self.keys() == other.keys(), \
+            f'{self.__class__}::__add__: Must have same types of images, had {self.keys()} and {other.keys()}'
 
-        new_layer = self.copy()
-        for (k,parity), image_block in other.items():
-            new_layer.append(k, parity, image_block)
+        return self.__class__.from_vector(self.to_vector() + other.to_vector(), self)
 
-        return new_layer
+    def __mul__(self, other):
+        """
+        Multiplication operator for a layer and a scalar
+        """
+        assert not isinstance(other, Layer), \
+            f'Layer multiplication is only implemented for numbers, got {type(other)}.'
+        
+        return self.__class__.from_vector(self.to_vector() * other, self)
+
+    def __truediv__(self, other):
+        """
+        True division (a/b) for a layer and a scalar.
+        """
+        return self * (1.0/other)
 
     def concat(self, other, axis=0):
         """
@@ -1705,6 +1721,13 @@ class Layer:
         out_layer = self.empty()
         for (k,parity), image_block in self.items():
             out_layer.append(k, parity, vmap_rotate(self.D, image_block, parity, gg, precision))
+
+        return out_layer
+
+    def norm(self):
+        out_layer = self.empty()
+        for image_block in self.values():
+            out_layer.append(0, 0, norm(self.D + 1, image_block)) # norm is even parity
 
         return out_layer
     
@@ -1834,6 +1857,10 @@ class BatchLayer(Layer):
     @partial(jax.vmap, in_axes=(None, 0, 0))
     def from_vector(cls, vector, layer):
         return super().from_vector(vector, layer)
+
+    @jax.vmap
+    def norm(self):
+        return super(BatchLayer, self).norm()
     
     def device_put(self, sharding, num_devices):
         """

--- a/src/geometricconvolutions/ml.py
+++ b/src/geometricconvolutions/ml.py
@@ -896,7 +896,7 @@ def _group_norm_K1(D, image_block, groups, method='eigh', eps=1e-5):
         )
     elif method == 'cholesky':
         L = jax.lax.linalg.cholesky(cov, symmetrize_input=False) # (batch*groups,D,D)
-        L + eps*jnp.eye(D).reshape((1,D,D,))
+        L = L + eps*jnp.eye(D).reshape((1,D,D,)) # Is this right?
         whitened_data = jax.lax.linalg.triangular_solve(
             L, 
             centered_img.reshape((batch*groups,-1) + (D,)),

--- a/src/geometricconvolutions/models.py
+++ b/src/geometricconvolutions/models.py
@@ -1,7 +1,10 @@
 import functools
 from collections import defaultdict
+import numpy as np
 
 import jax
+import jax.numpy as jnp
+import jax.random as random
 
 import geometricconvolutions.geometric as geom
 import geometricconvolutions.ml as ml
@@ -70,7 +73,7 @@ def handle_activation(activation_f, params, layer, mold_params):
     else:
         return ml.batch_scalar_activation(layer, activation_f), params
 
-@functools.partial(jax.jit, static_argnums=[3,4,5,6,7,10])
+@functools.partial(jax.jit, static_argnums=[3,4,5,6,7,10,11,12])
 def unetBase(
     params, 
     layer, 
@@ -84,6 +87,7 @@ def unetBase(
     upsample_filters=None, # 2x2 filters
     use_group_norm=True,
     return_params=False,
+    mold_params=None,
 ):
     """
     The U-Net from the original 2015 paper. The involves 4 downsampling steps and 4 upsampling steps, 
@@ -107,9 +111,13 @@ def unetBase(
         upsample_filters (Layer): the conv filters used for the upsample layer of the equivariant version
         use_group_norm (bool): whether to use group_norm, defaults to True
         return_params (bool): whether we are mapping the params, or applying them
+        mold_params (bool): 
     """
     num_downsamples = 4
     num_conv = 2
+
+    if mold_params is None:
+        mold_params = return_params
 
     assert output_keys is not None
 
@@ -135,11 +143,11 @@ def unetBase(
             depth,
             target_keys,
             bias=True,
-            mold_params=return_params,
+            mold_params=mold_params,
         )
         if use_group_norm:
-            layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=return_params)
-        layer, params = handle_activation(activation_f, params, layer, return_params)
+            layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=mold_params)
+        layer, params = handle_activation(activation_f, params, layer, mold_params)
 
     # first we do the downsampling
     residual_layers = []
@@ -157,11 +165,11 @@ def unetBase(
                 depth*(2**downsample),
                 target_keys,
                 bias=True,
-                mold_params=return_params,
+                mold_params=mold_params,
             )
             if use_group_norm:
-                layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=return_params)
-            layer, params = handle_activation(activation_f, params, layer, return_params)
+                layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=mold_params)
+            layer, params = handle_activation(activation_f, params, layer, mold_params)
 
     # now we do the upsampling and concatenation
     for upsample in reversed(range(num_downsamples)):
@@ -176,7 +184,7 @@ def unetBase(
             padding=((1,1),)*layer.D,
             lhs_dilation=(2,)*layer.D, # do the transposed convolution
             bias=True,
-            mold_params=return_params,
+            mold_params=mold_params,
         )
         # concat the upsampled layer and the residual
         layer = layer.concat(residual_layers[upsample], axis=1)
@@ -189,11 +197,11 @@ def unetBase(
                 depth*(2**upsample),
                 target_keys,
                 bias=True,
-                mold_params=return_params,
+                mold_params=mold_params,
             )
             if use_group_norm:
-                layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=return_params)
-            layer, params = handle_activation(activation_f, params, layer, return_params)
+                layer, params = ml.group_norm(params, layer, 1, equivariant=equivariant, mold_params=mold_params)
+            layer, params = handle_activation(activation_f, params, layer, mold_params)
 
     layer, params = ml.batch_conv_layer(
         params,
@@ -202,7 +210,7 @@ def unetBase(
         1, # depth
         output_keys,
         bias=True,
-        mold_params=return_params,
+        mold_params=mold_params,
     )
 
     return (layer, params) if return_params else layer
@@ -564,3 +572,152 @@ def do_nothing(params, layer, key, train, idxs, return_params=False):
         out_layer.append(k, parity, image_block[:,idx:idx+1])
 
     return (out_layer, params) if return_params else out_layer
+
+def group_average(
+    params, 
+    layer, 
+    key, 
+    train, 
+    model_f,
+    *args,
+    return_params=False,
+    **kwargs,
+): 
+    # if train:
+    #     return model_f(params, layer, key, train, *args, return_params=return_params, **kwargs)
+    # else: # results for validation sets during training will be different
+    group_operators = geom.make_all_operators(layer.D, with_inverses=True)
+    if return_params:
+        copy_params = { k:v for k,v in params.items() }
+        results = model_f(
+            copy_params, 
+            layer.times_group_element(group_operators[0][0]), 
+            key, 
+            train, 
+            *args,
+            return_params=return_params,
+            **kwargs,
+        )
+        out_params = results[1]
+        sum_layer = results[0].times_group_element(group_operators[0][1])
+        for gg, gg_inv in group_operators[1:]:
+            copy_params = { k:v for k,v in params.items() }
+            results = model_f(
+                copy_params, 
+                layer.times_group_element(gg), 
+                key, 
+                train, 
+                *args,
+                return_params=return_params,
+                **kwargs,
+            )
+            sum_layer = sum_layer + results[0].times_group_element(gg_inv)
+
+        return sum_layer / len(group_operators), out_params
+    else:
+        # do the group averaging
+        copy_params = { k:v for k,v in params.items() }
+        sum_layer = model_f(
+            copy_params, 
+            layer.times_group_element(group_operators[0][0]), 
+            key, 
+            train, 
+            *args,
+            return_params=return_params,
+            **kwargs,
+        ).times_group_element(group_operators[0][1])
+        for gg, gg_inv in group_operators[1:]:
+            copy_params = { k:v for k,v in params.items() }
+            out = model_f(
+                copy_params, 
+                layer.times_group_element(gg), 
+                key, 
+                train, 
+                *args,
+                return_params=return_params,
+                **kwargs,
+            ).times_group_element(gg_inv)
+            sum_layer = sum_layer + out
+
+        return sum_layer/len(group_operators)
+
+def unetBase_approx_equiv(
+    params, 
+    layer, 
+    key, 
+    train, 
+    output_keys=None,
+    depth=64, 
+    activation_f=jax.nn.gelu,
+    conv_filters=None, 
+    upsample_filters=None, # 2x2 filters
+    use_group_norm=True,
+    scale_adjust=0.1,
+    return_params=False,
+):
+    """
+    The U-Net Base model that uses an equivariant model and a vanilla model. The involves 4 downsampling
+    steps and 4 upsampling steps, 
+    each interspersed with 2 convolutions interleaved with scalar activations and batch norm. The downsamples
+    are achieved with max_pool layers with patch length of 2 and the upsamples are achieved with transposed
+    convolution. Additionally, there are residual connections after every downsample and upsample. For the 
+    equivariant version, we use invariant filters, norm max_pool, and no batch_norm.
+    args:
+        params (params tree): the params of the model
+        layer (BatchLayer): input batch layer
+        key (jnp.random key): key for any layers requiring randomization
+        train (bool): whether train mode or test mode, relevant for batch_norm
+        batch_stats (dict): state for batch_norm, default None
+        output_keys (tuple of tuples of ints): the output key types of the model. For the Shallow Water
+            experiments, should be ((0,0),(1,0)) for the pressure/velocity form and ((0,0),(0,1)) for 
+            the pressure/vorticity form.
+        depth (int): the depth of the layers, defaults to 64
+        activation_f (string or function): the function that we pass to batch_scalar_activation
+        equivariant (bool): whether to use the equivariant version of the model, defaults to False
+        conv_filters (Layer): the conv filters used for the equivariant version
+        upsample_filters (Layer): the conv filters used for the upsample layer of the equivariant version
+        use_group_norm (bool): whether to use group_norm, defaults to True
+        return_params (bool): whether we are mapping the params, or applying them
+    """
+    equiv_layer, params = unetBase(
+        params, 
+        layer, 
+        key, 
+        train, 
+        output_keys,
+        depth, 
+        activation_f,
+        True, # equivariant
+        conv_filters, 
+        upsample_filters, # 2x2 filters
+        use_group_norm,
+        return_params=True,
+        mold_params=return_params,
+    )
+
+    free_result = unetBase(
+        params, 
+        layer, 
+        key, 
+        train, 
+        output_keys,
+        depth*2, 
+        equivariant=False,
+        return_params=return_params,
+    )
+
+    if return_params:
+        free_layer = free_result[0]
+        params = free_result[1]
+    else:
+        free_layer = free_result
+
+    # scale the non-equivariant result to have 1/10th of max norm
+    equiv_max_norm = jnp.max(equiv_layer.norm().to_vector())
+    free_max_norm = jnp.max(free_layer.norm().to_vector())
+    scale = (equiv_max_norm / free_max_norm)*scale_adjust
+
+    if return_params:
+        return equiv_layer + (free_layer*scale), params
+    else:
+        return equiv_layer + (free_layer*scale)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -49,6 +49,13 @@ class TestMisc:
             # test the group size
             assert len(operators) == 2*(2**(d-1))*math.factorial(d)
 
+    def testGetOperatorsWithInverses(self):
+        for D in [2,3]:
+            operators_with_inverses = geom.make_all_operators(D, with_inverses=True)
+            for gg, gg_inv in operators_with_inverses:
+                assert jnp.allclose(gg @ gg_inv, jnp.eye(D), atol=geom.TINY, rtol=geom.TINY)
+                assert jnp.allclose(gg_inv @ gg, jnp.eye(D), atol=geom.TINY, rtol=geom.TINY) 
+
     def testGetContractionIndices(self):
         idxs = geom.get_contraction_indices(3,1)
         known_list = [((0,1),), ((0,2),), ((1,2),)]
@@ -295,4 +302,58 @@ class TestMisc:
                                 output_data[b,i], 
                                 img_data[b,i+past_steps:i+past_steps+future_steps],
                             )
+
+    def testTimeSeriesToLayers(self):
+        key = random.PRNGKey(time.time_ns())
+        D = 2
+        batch = 5
+        timesteps = 20
+        N = 5
+        past_steps = 4
+        future_steps = 1
+
+        # test basic dynamic fields
+        key, subkey1, subkey2 = random.split(key, 3)
+        dynamic_fields = {
+            (0,0): random.normal(subkey1, shape=(batch,timesteps) + (N,)*D),
+            (1,0): random.normal(subkey2, shape=(batch,timesteps) + (N,)*D + (D,)),
+        }
+
+        X, Y = gc_data.times_series_to_layers(D, dynamic_fields, {}, False, past_steps, future_steps)
+        num_windows = timesteps-past_steps-future_steps+1 # sliding window per original trajectory
+        assert isinstance(X, geom.BatchLayer) and isinstance(Y, geom.BatchLayer)
+        assert list(X.keys()) == [(0,0),(1,0)]
+        assert X[(0,0)].shape == ((batch*num_windows,past_steps) + (N,)*D)
+        assert X[(1,0)].shape == ((batch*num_windows,past_steps) + (N,)*D + (D,))
+        assert jnp.allclose(X[(0,0)][0], dynamic_fields[(0,0)][0,:past_steps])
+        assert jnp.allclose(X[(1,0)][0], dynamic_fields[(1,0)][0,:past_steps])
+
+        assert Y[(0,0)].shape == ((batch*num_windows,future_steps) + (N,)*D)
+        assert Y[(1,0)].shape == ((batch*num_windows,future_steps) + (N,)*D + (D,))
+        assert jnp.allclose(Y[(0,0)][0], dynamic_fields[(0,0)][0,past_steps:past_steps+future_steps])
+        assert jnp.allclose(Y[(1,0)][0], dynamic_fields[(1,0)][0,past_steps:past_steps+future_steps])
+
+        # test with a constant fields
+        key, subkey3 = random.split(key)
+        constant_fields = { (1,0): random.normal(subkey3, shape=(batch,) + (N,)*D + (D,)) }
+
+        X2, Y2 = gc_data.times_series_to_layers(
+            D, 
+            dynamic_fields, 
+            constant_fields, 
+            False, 
+            past_steps, 
+            future_steps,
+        )
+        assert list(X.keys()) == [(0,0),(1,0)]
+        assert X2[(0,0)].shape == ((batch*num_windows,past_steps) + (N,)*D)
+        assert X2[(1,0)].shape == ((batch*num_windows,past_steps+1) + (N,)*D + (D,))
+        assert jnp.allclose(X2[(0,0)][0,:past_steps], dynamic_fields[(0,0)][0,:past_steps])
+        assert jnp.allclose(X2[(1,0)][0,:past_steps], dynamic_fields[(1,0)][0,:past_steps])
+        assert jnp.allclose(X2[(1,0)][0,past_steps], constant_fields[(1,0)][0])
+
+        assert Y2[(0,0)].shape == ((batch*num_windows,future_steps) + (N,)*D)
+        assert Y2[(1,0)].shape == ((batch*num_windows,future_steps) + (N,)*D + (D,))
+        assert jnp.allclose(Y2[(0,0)][0], dynamic_fields[(0,0)][0,past_steps:past_steps+future_steps])
+        assert jnp.allclose(Y2[(1,0)][0], dynamic_fields[(1,0)][0,past_steps:past_steps+future_steps])
                     


### PR DESCRIPTION
## Changes
- include buoyancy in turb2d simulations, necessary for equivariance
- swap addition of layers to add them instead of concatenate them, use .concat for concatenation


## Testing
- [ ] turb2d.py
- [ ] gravity_field.py
- [ ] gravity_benchmark.py
- [ ] unit tests

## Doc Changes
- none