### PR TITLE
Model speedup

### DIFF
--- a/scripts/cfd_2d.py
+++ b/scripts/cfd_2d.py
@@ -72,13 +72,14 @@ def get_data(
             velocity[: (n_train + n_val)]
         )  # this one I am not so sure about
 
+    is_torus = True
     start = 0
     stop = n_train
     train_X, train_Y = gc_data.times_series_to_layers(
         D,
         {(0, 0): density[start:stop], (1, 0): velocity[start:stop]},
         {},
-        True,
+        is_torus,
         past_steps,
         1,
     )
@@ -86,7 +87,7 @@ def get_data(
         D,
         {(0, 0): pressure[start:stop]},
         {},
-        True,
+        is_torus,
         past_steps,
         1,
     )
@@ -99,7 +100,7 @@ def get_data(
         D,
         {(0, 0): density[start:stop], (1, 0): velocity[start:stop]},
         {},
-        True,
+        is_torus,
         past_steps,
         1,
     )
@@ -107,7 +108,7 @@ def get_data(
         D,
         {(0, 0): pressure[start:stop]},
         {},
-        True,
+        is_torus,
         past_steps,
         1,
     )
@@ -120,7 +121,7 @@ def get_data(
         D,
         {(0, 0): density[start:stop], (1, 0): velocity[start:stop]},
         {},
-        True,
+        is_torus,
         past_steps,
         1,
     )
@@ -128,7 +129,7 @@ def get_data(
         D,
         {(0, 0): pressure[start:stop]},
         {},
-        True,
+        is_torus,
         past_steps,
         1,
     )
@@ -139,7 +140,7 @@ def get_data(
         D,
         {(0, 0): density[start:stop], (1, 0): velocity[start:stop]},
         {},
-        True,
+        is_torus,
         past_steps,
         rollout_steps,
     )
@@ -147,7 +148,7 @@ def get_data(
         D,
         {(0, 0): pressure[start:stop]},
         {},
-        True,
+        is_torus,
         past_steps,
         rollout_steps,
     )

--- a/src/geometricconvolutions/geometric.py
+++ b/src/geometricconvolutions/geometric.py
@@ -333,6 +333,7 @@ def get_unique_invariant_filters(
     # normalize the amplitudes so they max out at +/- 1.
     amps = v[sbig] / jnp.max(jnp.abs(v[sbig]), axis=1, keepdims=True)
     # make sure the amps are positive, generally
+    amps = jnp.round(amps, decimals=5) + 0.0
     signs = jnp.sign(jnp.sum(amps, axis=1, keepdims=True))
     signs = jnp.where(
         signs == 0, jnp.ones(signs.shape), signs
@@ -484,7 +485,6 @@ def hash(D: int, image: jnp.ndarray, indices: jnp.ndarray) -> tuple[jnp.ndarray]
 
 
 def get_torus_expanded(
-    D: int,
     image: jnp.ndarray,
     is_torus: tuple[bool],
     filter_spatial_dims: tuple[int],
@@ -495,26 +495,23 @@ def get_torus_expanded(
     just doing convolutions on the expanded image and will get the same result. Return a new GeometricImage
     args:
         D (int): dimension of the image
-        image (jnp.array): image data
+        image (jnp.array): image data, (batch,spatial,channels)
         is_torus (tuple of bool): d-length tuple of bools specifying which spatial dimensions are toroidal
         filter_spatial_dims (tuple of ints): the spatial dimensions of the filter
         rhs_dilation (tuple of int): dilation to apply to each filter dimension D
     """
-    spatial_dims, img_k = parse_shape(image.shape, D)
     # assert all the filter side lengths are odd
     assert reduce(lambda carry, M: carry and (M % 2 == 1), filter_spatial_dims, True)
 
     # for each torus dimension, calculate the torus padding
-    padding_f = lambda M, dilation, torus: (((M - 1) // 2) * dilation) if torus else 0
+    padding_f = lambda M, dilation, torus: ((((M - 1) // 2) * dilation),) * 2 if torus else (0, 0)
     zipped_dims = zip(filter_spatial_dims, rhs_dilation, is_torus)
     torus_padding = tuple(padding_f(M, dilation, torus) for M, dilation, torus in zipped_dims)
 
     # calculate indices for torus padding, then use hash to select the appropriate pixels
-    ranges = list(jnp.arange(-pad, N + pad) for N, pad in zip(spatial_dims, torus_padding))
-    mesh = jnp.stack(jnp.meshgrid(*ranges, indexing="ij"), axis=-1)
-    new_spatial_dims = mesh.shape[:D]
-    indices = mesh.reshape((np.multiply.reduce(new_spatial_dims), D))
-    expanded_image = image[hash(D, image, indices)].reshape(new_spatial_dims + (D,) * img_k)
+    # print(image.shape)
+    # print(((0, 0),) + torus_padding + ((0, 0),))
+    expanded_image = jnp.pad(image, ((0, 0),) + torus_padding + ((0, 0),), mode="wrap")
 
     # zero_pad where we don't torus pad
     zero_padding = get_same_padding(
@@ -674,21 +671,101 @@ def convolve(
     returns: (jnp.array) convolved_image, shape (batch,out_c,spatial,tensor)
     """
     assert (D == 2) or (D == 3)
-    assert (isinstance(is_torus, tuple) and len(is_torus) == D) or isinstance(is_torus, bool), (
-        "geom::convolve" f" is_torus must be bool or tuple of bools, but got {is_torus}"
-    )
     assert image.shape[1] == filter_image.shape[1], (
         f"Second axis (in_channels) for image and filter_image "
         f"must equal, but got image {image.shape} and filter {filter_image.shape}"
     )
-    dtype = "float32"
-
-    if isinstance(is_torus, bool):
-        is_torus = (is_torus,) * D
 
     filter_spatial_dims, _ = parse_shape(filter_image.shape[2:], D)
     out_c, in_c = filter_image.shape[:2]
     batch = len(image)
+
+    if tensor_expand:
+        img_expanded, filter_expanded = pre_tensor_product_expand(
+            D,
+            image,
+            filter_image,
+            a_offset=2,
+            b_offset=2,
+            dtype="float32",
+        )
+    else:
+        img_expanded, filter_expanded = image, filter_image
+
+    _, output_k = parse_shape(filter_expanded.shape[2:], D)
+    image_spatial_dims, input_k = parse_shape(img_expanded.shape[2:], D)
+    channel_length = D**input_k
+
+    # convert the image to NHWC (or NHWDC), treating all the pixel values as channels
+    # (batch,in_c,spatial,in_tensor) -> (batch,spatial,in_tensor,in_c)
+    img_formatted = jnp.moveaxis(img_expanded, 1, -1)
+    # (batch,spatial,in_tensor,in_c) -> (batch,spatial,in_tensor*in_c)
+    img_formatted = img_formatted.reshape((batch,) + image_spatial_dims + (channel_length * in_c,))
+
+    # convert filter to HWIO (or HWDIO)
+    # (out_c,in_c,spatial,out_tensor) -> (spatial,in_c,out_tensor,out_c)
+    filter_formatted = jnp.moveaxis(jnp.moveaxis(filter_expanded, 0, -1), 0, D)
+    # (spatial,in_c,out_tensor,out_c) -> (spatial,in_c,out_tensor*out_c)
+    filter_formatted = filter_formatted.reshape(
+        filter_spatial_dims + (in_c, channel_length * out_c)
+    )
+
+    # (batch,spatial,out_tensor*out_c)
+    convolved_array = convolve_ravel(
+        D, img_formatted, filter_formatted, is_torus, stride, padding, lhs_dilation, rhs_dilation
+    )
+    out_shape = convolved_array.shape[:-1] + (D,) * output_k + (out_c,)
+    return jnp.moveaxis(convolved_array.reshape(out_shape), -1, 1)  # move out_c to 2nd axis
+
+
+@eqx.filter_jit
+def convolve_ravel(
+    D: int,
+    image: jnp.ndarray,
+    filter_image: jnp.ndarray,
+    is_torus: Union[tuple[bool], bool],
+    stride: Optional[tuple[int]] = None,
+    padding: Optional[tuple[int]] = None,
+    lhs_dilation: Optional[tuple[int]] = None,
+    rhs_dilation: Optional[tuple[int]] = None,
+) -> jnp.ndarray:
+    """
+    Here is how this function works:
+    1. Expand the geom_image to its torus shape, i.e. add filter.m cells all around the perimeter of the image
+    2. Do the tensor product (with 1s) to each image.k, filter.k so that they are both image.k + filter.k tensors.
+    That is if image.k=2, filter.k=1, do (D,D) => (D,D) x (D,) and (D,) => (D,D) x (D,) with tensors of 1s
+    3. Now we shape the inputs to work with jax.lax.conv_general_dilated
+    4. Put image in NHWC (batch, height, width, channel). Thus we vectorize the tensor
+    5. Put filter in HWIO (height, width, input, output). Input is 1, output is the vectorized tensor
+    6. Plug all that stuff in to conv_general_dilated, and feature_group_count is the length of the vectorized
+    tensor, and it is basically saying that each part of the vectorized tensor is treated separately in the filter.
+    It must be the case that channel = input * feature_group_count
+    See: https://jax.readthedocs.io/en/latest/notebooks/convolutions.html#id1 and
+    https://www.tensorflow.org/xla/operation_semantics#conv_convolution
+
+    args:
+        D (int): dimension of the images
+        image (jnp.array): image data, shape (batch,spatial,tensor*in_c)
+        filter_image (jnp.array): the convolution filter, shape (spatial,in_c,tensor*out_c)
+        is_torus (bool or tuple of bool): what dimensions of the image are toroidal
+        stride (tuple of ints): convolution stride, defaults to (1,)*self.D
+        padding (either 'TORUS','VALID', 'SAME', or D length tuple of (upper,lower) pairs):
+            defaults to 'TORUS' if image.is_torus, else 'SAME'
+        lhs_dilation (tuple of ints): amount of dilation to apply to image in each dimension D, also transposed conv
+        rhs_dilation (tuple of ints): amount of dilation to apply to filter in each dimension D, defaults to 1
+        tensor_expand (bool): expand the tensor of image and filter to do tensor convolution, defaults to True.
+            If there is something more complicated going on (e.g. conv_contract), you can skip this step.
+    returns: (jnp.array) convolved_image, shape (batch,out_c,spatial,tensor)
+    """
+    assert (D == 2) or (D == 3)
+    assert (isinstance(is_torus, tuple) and len(is_torus) == D) or isinstance(is_torus, bool), (
+        "geom::convolve" f" is_torus must be bool or tuple of bools, but got {is_torus}"
+    )
+
+    if isinstance(is_torus, bool):
+        is_torus = (is_torus,) * D
+
+    filter_spatial_dims, _ = parse_shape(filter_image.shape, D)
 
     assert not (
         reduce(lambda carry, N: carry or (N % 2 == 0), filter_spatial_dims, False)
@@ -711,10 +788,8 @@ def convolve(
         )
 
     if padding == "TORUS":
-        in_axes, out_axes = (None, 0, None, None, None), (0, None)
-        vmap_torus_expand = vmap(vmap(get_torus_expanded, in_axes, out_axes), in_axes, out_axes)
-        image, padding_literal = vmap_torus_expand(
-            D, image, is_torus, filter_spatial_dims, rhs_dilation
+        image, padding_literal = get_torus_expanded(
+            image, is_torus, filter_spatial_dims, rhs_dilation
         )
     elif padding == "VALID":
         padding_literal = ((0, 0),) * D
@@ -723,41 +798,13 @@ def convolve(
     else:
         padding_literal = padding
 
-    if tensor_expand:
-        img_expanded, filter_expanded = pre_tensor_product_expand(
-            D,
-            image,
-            filter_image,
-            a_offset=2,
-            b_offset=2,
-            dtype=dtype,
-        )
-    else:
-        img_expanded, filter_expanded = image, filter_image
-
-    _, output_k = parse_shape(filter_expanded.shape[2:], D)
-    image_spatial_dims, input_k = parse_shape(img_expanded.shape[2:], D)
-    channel_length = D**input_k
-
-    # convert the image to NHWC (or NHWDC), treating all the pixel values as channels
-    # (batch,in_c,spatial,in_tensor) -> (batch,spatial,in_tensor,in_c)
-    img_formatted = jnp.moveaxis(img_expanded, 1, -1)
-    # (batch,spatial,in_tensor,in_c) -> (batch,spatial,in_tensor*in_c)
-    img_formatted = img_formatted.reshape((batch,) + image_spatial_dims + (channel_length * in_c,))
-
-    # convert filter to HWIO (or HWDIO)
-    # (out_c,in_c,spatial,out_tensor) -> (spatial,in_c,out_tensor,out_c)
-    transpose_idxs = (
-        tuple(range(2, 2 + D)) + (1,) + tuple(range(2 + D, filter_expanded.ndim)) + (0,)
-    )
-    filter_formatted = filter_expanded.transpose(transpose_idxs)
-    # (spatial,in_c,out_tensor,out_c) -> (spatial,in_c,out_tensor*out_c)
-    filter_formatted = filter_formatted.reshape(filter_spatial_dims + (in_c, D**output_k * out_c))
+    assert (image.shape[-1] // filter_image.shape[-2]) == (image.shape[-1] / filter_image.shape[-2])
+    channel_length = image.shape[-1] // filter_image.shape[-2]
 
     # (batch,spatial,out_tensor*out_c)
     convolved_array = jax.lax.conv_general_dilated(
-        img_formatted,  # lhs
-        filter_formatted,  # rhs
+        image,  # lhs
+        filter_image,  # rhs
         stride,
         padding_literal,
         lhs_dilation=lhs_dilation,
@@ -765,8 +812,7 @@ def convolve(
         dimension_numbers=(("NHWC", "HWIO", "NHWC") if D == 2 else ("NHWDC", "HWDIO", "NHWDC")),
         feature_group_count=channel_length,  # each tensor component is treated separately
     )
-    out_shape = convolved_array.shape[:-1] + (D,) * output_k + (out_c,)
-    return jnp.moveaxis(convolved_array.reshape(out_shape), -1, 1)  # move out_c to 2nd axis
+    return convolved_array
 
 
 @eqx.filter_jit
@@ -791,6 +837,8 @@ def convolve_contract(
     returns: (jnp.array) output of shape (batch,out_c,spatial,tensor)
     """
     _, img_k = parse_shape(image.shape[2:], D)
+    _, filter_k = parse_shape(filter_image.shape[2:], D)
+    image = conv_contract_image_expand(D, image, filter_k)
     convolved_img = convolve(
         D,
         image,

--- a/tests/test_functional_geometric_image.py
+++ b/tests/test_functional_geometric_image.py
@@ -280,11 +280,7 @@ class TestFunctionalGeometricImage:
             [
                 [
                     [
-                        [
-                            2,
-                            1,
-                            0,
-                        ],
+                        [2, 1, 0],
                         [0, 0, -3],
                         [2, 0, 1],
                     ],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,12 @@
+import time
+import itertools as it
+
 import jax.numpy as jnp
 from jax import random
 
 import geometricconvolutions.geometric as geom
 import geometricconvolutions.models as models
+import geometricconvolutions.ml_eqx as ml_eqx
 
 
 class TestModels:
@@ -70,3 +74,48 @@ class TestModels:
                 {}, vec.times_group_element(gg), subkey2, None, equiv_function
             )
             assert first == second
+
+    def testConvContract2D(self):
+        D = 2
+        M = 3
+        N = 5
+        in_c = 3
+        out_c = 4
+        max_k = 2
+        ks = list(range(max_k + 1))
+        parities = [0, 1]
+        ks_ps_prod = list(it.product(ks, parities))
+        key = random.PRNGKey(time.time_ns())
+
+        conv_filters = geom.get_invariant_filters([M], ks, parities, D, geom.make_all_operators(D))
+
+        # power set (excluding empty set) of possible in_k, out_k and parity
+        powerset = list(
+            it.chain.from_iterable(
+                it.combinations(ks_ps_prod, r + 1) for r in range(len(ks_ps_prod))
+            )
+        )
+        for in_ks_ps in powerset:
+            for out_ks_ps in powerset:
+                input_keys = tuple((in_key, in_c) for in_key in in_ks_ps)
+                target_keys = tuple((out_key, out_c) for out_key in out_ks_ps)
+
+                key, *subkeys = random.split(key, num=len(input_keys) + 1)
+                layer = geom.Layer(
+                    {
+                        (k, p): random.normal(subkeys[i], shape=(in_c,) + (N,) * D + (D,) * k)
+                        for i, ((k, p), _) in enumerate(input_keys)
+                    },
+                    D,
+                )
+
+                key, subkey = random.split(key)
+                conv = ml_eqx.ConvContract(
+                    input_keys, target_keys, conv_filters, use_bias=False, key=subkey
+                )
+                if conv.missing_filter:
+                    continue
+
+                assert conv.fast_convolve(layer, conv.weights) == conv.individual_convolve(
+                    layer, conv.weights
+                )


### PR DESCRIPTION
## Changes
- use jnp.pad for toroidal padding
- write convolve_ravel to efficiently combine all convolutions between different tensor orders into a single operation
- swap ConvContract so that it automatically uses fast_mode (convolve_ravel) if possible. This only gets ~20% speedup, but so there could be improvements to be made in the future.
- there is also now a warning about slowness because of constant folding. Future todo to fix this, or at least silence the error.

## Testing
- run pytest
- run cfd_2d.py with fastmode

## Doc Changes