### PR TITLE
install gc during preinstall, not during install

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
   tools:
     python: "3.11"
   jobs:
-    install:
+    pre_install:
       - pip install .
 
 mkdocs:


### PR DESCRIPTION
- I think I accidentally overwrite the default install for mkdocs