### PR TITLE
add train time, other timings to anyd

### DIFF
--- a/examples/conversion_example.ipynb
+++ b/examples/conversion_example.ipynb
@@ -724,7 +724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -774,7 +774,7 @@
     "for model_name, model, lr in model_list:\n",
     "    print(f'{model_name} ({models.count_params(model)}), {lr}')\n",
     "    key, subkey = random.split(key)\n",
-    "    trained_model, _, train_loss, val_loss = ml.train(\n",
+    "    trained_model, _, train_loss, val_loss, _ = ml.train(\n",
     "        train_X, \n",
     "        train_Y, \n",
     "        map_and_loss, \n",

--- a/examples/gradient_example.ipynb
+++ b/examples/gradient_example.ipynb
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -375,7 +375,7 @@
     "for model_name, model, lr in model_list:\n",
     "    print(model_name, lr)\n",
     "    key, subkey = random.split(key)\n",
-    "    trained_model, _, train_loss, val_loss = ml.train(\n",
+    "    trained_model, _, train_loss, val_loss, _ = ml.train(\n",
     "        train_x, \n",
     "        train_y, \n",
     "        map_and_loss, \n",

--- a/examples/scalar_example.ipynb
+++ b/examples/scalar_example.ipynb
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -191,7 +191,7 @@
     ")\n",
     "\n",
     "key, subkey = random.split(key)\n",
-    "trained_model, _, _, _ = ml.train(\n",
+    "trained_model, _, _, _, _ = ml.train(\n",
     "    multi_image_X,\n",
     "    multi_image_y,\n",
     "    map_and_loss,\n",

--- a/scripts/burgers_anyd.py
+++ b/scripts/burgers_anyd.py
@@ -5,6 +5,7 @@ from matplotlib.axes import Axes
 import numpy as np
 import pathlib
 import time
+from typing import Callable
 from typing_extensions import Self
 
 import jax
@@ -30,7 +31,7 @@ def get_data_d(
     n_batch: int,
     key: jax.Array,
     data_dir: pathlib.Path,
-) -> tuple[geom.MultiImage, geom.MultiImage]:
+) -> tuple[geom.MultiImage, geom.MultiImage, float]:
     """
     Generate data for a particular dimension using the apebench code.
 
@@ -136,7 +137,22 @@ def get_data_d(
         geom.MultiImage({(1, 0): train_data}, D, is_torus), constant_fields, n_timesteps, 1, 1
     )
 
-    return x0, xt
+    # dictionary by D, then n_batch
+    # Since these values aren't saved with the data, hardcode them from some previous run.
+    data_generation_times = {
+        2: {
+            0: jnp.array([1.0652430057525635, 0.40758848190307617]),
+            8: jnp.array([7.801406621932983, 3.1244280338287354]),
+        },
+        3: {
+            0: jnp.array([0.6283245086669922, 2.0740256309509277, 0.9826910495758057]),
+            1: jnp.array([5.805211067199707]),
+            4: jnp.array([7.013747453689575]),
+            8: jnp.array([8.912535429000854, 5.779284477233887, 7.701824903488159]),
+        },
+    }
+
+    return x0, xt, float(jnp.mean(data_generation_times[D][n_batch]))
 
 
 def get_data(
@@ -157,6 +173,7 @@ def get_data(
     geom.MultiImage,
     geom.MultiImage,
     geom.MultiImage,
+    float,
 ]:
     """
     Generate full dataset with train, validation, and test data sets.
@@ -179,19 +196,19 @@ def get_data(
     data_dir_path = pathlib.Path(data_dir)
 
     key, subkey1, subkey2, subkey3 = random.split(key, num=4)
-    train_x0, train_xt = get_data_d(
+    train_x0, train_xt, train_data_time = get_data_d(
         D, N, diffusion_coef, convection_coef, subsample, n_train, subkey1, data_dir_path / "train"
     )
 
-    val_x0, val_xt = get_data_d(
+    val_x0, val_xt, _ = get_data_d(
         D, N, diffusion_coef, convection_coef, subsample, n_val, subkey2, data_dir_path / "val"
     )
 
-    test_x0, test_xt = get_data_d(
+    test_x0, test_xt, _ = get_data_d(
         D, N, diffusion_coef, convection_coef, subsample, n_test, subkey3, data_dir_path / "test"
     )
 
-    return train_x0, train_xt, val_x0, val_xt, test_x0, test_xt
+    return train_x0, train_xt, val_x0, val_xt, test_x0, test_xt, train_data_time
 
 
 def plot_results(
@@ -267,10 +284,90 @@ def plot_results(
         ax.set_ylabel(ylabel)
         ax.set_yscale("log")
         ax.set_xticks(range(len(n_tune_range)), [str(x) for x in n_tune_range])
-        ax.set_title(f"Test D={test_D} {ylabel}")
+        ax.set_title(f"Burgers' Equation 2D -> 3D {ylabel}")
 
     plt.tight_layout()
-    plt.savefig(f"{saveloc}warmstart_plot.png")
+    plt.savefig(f"{saveloc}burgers_warmstart_plot.png")
+    plt.close()
+
+
+def plot_time_results(
+    results_dict: dict[int, list[jax.Array]],
+    results_labels: list[str],
+    model_names_d: dict[int, list[str]],
+    saveloc: str,
+) -> None:
+    """
+    Plot the results of each model versus the time it took to get those results, including the time
+    to generate the training data.
+
+    args:
+        results_dict: The results dict of test_D, then a list over n_tune, array n_results
+            in this case n_results is smse_mean, smse_std, rel_mean, rel_std
+        results_labels: e.g. 'l2', 'relative error'
+        model_names_d: model names for each dimension
+        saveloc: beginning of save location
+
+    returns:
+        none
+    """
+    # group the results by model, across all trained dimensions
+    results_by_model = {}
+    for train_D, results in results_dict.items():
+        for i, name in enumerate(model_names_d[train_D]):
+            name_trimmed = name[:-3]  # this assumes that all models end in _D2, or _D3
+            display_name = f"{name} (baseline)" if train_D == 3 else name
+
+            if name_trimmed in results_by_model:
+                # (n_tune,n_trials,n_results)
+                results_by_model[name_trimmed].append(
+                    (display_name, jnp.stack(results)[:, :, 0, i])
+                )
+            else:
+                results_by_model[name_trimmed] = [(display_name, jnp.stack(results)[:, :, 0, i])]
+
+    # figsize is 8 per col, 6 per row, (cols,rows)
+    nrows = 1  # D=3 is the only test dimension
+    ncols = len(results_labels)
+    _, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(8 * ncols, 6 * nrows))
+    linestyles = ["solid", "dotted", "dashed", "dashdot"]
+    colors = ["b", "g", "r", "c", "m", "y"]
+
+    for error_idx, ylabel, ax in zip(range(len(results_labels)), results_labels, axes):
+        assert isinstance(ax, Axes)
+
+        # looping over 'two_layer_gaussian', 'resnet_equiv_42', ...
+        for i, model_results in enumerate(results_by_model.values()):
+            for j, (display_name, results_arr) in enumerate(model_results):
+
+                # mean is over trials
+                times = jnp.mean(results_arr, axis=1)[:, -1] / 60
+                mean_result = jnp.mean(results_arr, axis=1)[:, error_idx * 2]
+                stdev = jnp.mean(results_arr, axis=1)[:, error_idx * 2 + 1]
+                ax.plot(
+                    times,
+                    mean_result,
+                    marker="o",
+                    linestyle=linestyles[j],
+                    label=display_name,
+                    color=colors[j],  # was i, currently only model
+                )
+                ax.fill_between(
+                    times,
+                    mean_result - stdev,
+                    mean_result + stdev,
+                    color=colors[j],
+                    alpha=0.2,
+                )
+
+        ax.legend()
+        ax.set_xlabel("Total time (minutes)")
+        ax.set_ylabel(ylabel)
+        ax.set_yscale("log")
+        ax.set_title(f"Burgers' Equation 2D -> 3D {ylabel}")
+
+    plt.tight_layout()
+    plt.savefig(f"{saveloc}burgers_warmstart_time_plot.png")
     plt.close()
 
 
@@ -416,7 +513,7 @@ def train_model(
     has_aux: bool = False,
     verbose: int = 1,
     is_wandb: bool = False,
-) -> models.MultiImageModule:
+) -> tuple[models.MultiImageModule, float]:
     train_X, train_Y, val_X, val_Y = data
     N = train_X.get_spatial_dims()[0]
     batch_stats = eqx.nn.State(model) if has_aux else None
@@ -426,11 +523,12 @@ def train_model(
     print(f"{model_name_extended} params: {models.count_params(model):,}")
 
     if model_path and model_path.is_file() and not overwrite_save_model:
-        trained_model = ml.load(model_path, model)
+        trained_model, further_args = ml.load_plus(model_path, model)
+        train_time = further_args["train_time"]
     else:
         steps_per_epoch = int(math.ceil(train_X.get_L() / batch_size))
         key, subkey = random.split(key)
-        trained_model, _, _, _ = ml.train(
+        trained_model, _, _, _, train_time = ml.train(
             train_X,
             train_Y,
             ml.Mapper([geom.Losses.NRMSE], residual),
@@ -453,7 +551,7 @@ def train_model(
         if model_path:
             assert not model_path.is_file() or overwrite_save_model
             # TODO: need to save batch_stats as well
-            ml.save(model_path, trained_model)
+            ml.save_plus(model_path, trained_model, {"train_time": train_time})
 
     assert trained_model is not None
     if images_dir and val_X.D == 2:
@@ -468,7 +566,7 @@ def train_model(
             "burgers",
         )
 
-    return trained_model
+    return trained_model, train_time
 
 
 def train_all_models(
@@ -482,11 +580,12 @@ def train_all_models(
     model_list: list[tuple[str, dict, dict]],
     lr_range,
     args: argparse.Namespace,
-):
+) -> tuple[list[tuple[str, Callable, dict]], list[float]]:
     train_D = data[0].D
     n_points = data[0].get_L()
 
     trained_models = []
+    train_times = []
     for model_name, _train_kwargs, _test_kwargs in model_list:
         key, subkey = random.split(key)
         if args.find_train_lr:
@@ -513,11 +612,12 @@ def train_all_models(
                 },
             )
         else:
-            trained_model = train_model(data, subkey, model_name, **_train_kwargs)
+            trained_model, train_time = train_model(data, subkey, model_name, **_train_kwargs)
             _test_kwargs = {**_test_kwargs, "model": trained_model}
             trained_models.append((model_name, tune_and_eval, _test_kwargs))
+            train_times.append(train_time)
 
-    return trained_models
+    return trained_models, train_times
 
 
 def tune_and_eval(
@@ -545,7 +645,7 @@ def tune_and_eval(
     has_aux: bool = False,
     verbose: int = 1,
     is_wandb: bool = False,
-) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, float]:
     tune_X, tune_Y, val_X, val_Y, test_X, test_Y = data
     N = tune_X.get_spatial_dims()[0]
     batch_stats = eqx.nn.State(model) if has_aux else None
@@ -555,24 +655,28 @@ def tune_and_eval(
     key, subkey = random.split(key)
     # rescale set to True, small but notable difference
     if conv_filters_dict is not None and rescale is not None:
+        start_time = time.time()
         model_dprime = model.convertD(
             conv_filters_dict[tune_X.D],
             rescale,
             subkey,
             upsample_filters=upsample_filters_dict[tune_X.D] if upsample_filters_dict else None,
         )
+        convert_time = time.time() - start_time
     else:
         model_dprime = model
+        convert_time = 0
 
     if model_path and model_path.is_file() and not overwrite_save_model:
-        tuned_model_dprime = ml.load(model_path, model_dprime)
+        tuned_model_dprime, further_args = ml.load_plus(model_path, model_dprime)
+        tune_time = further_args["train_time"]
         tune_batch_stats = batch_stats
     else:
         if tune_X.get_L() > 0:
             # Now treat the trained_model_d as a warmstart and do some additional training
             key, subkey = random.split(key)
             steps_per_epoch = int(math.ceil(tune_X.get_L() / batch_size))
-            tuned_model_dprime, tune_batch_stats, _, _ = ml.train(
+            tuned_model_dprime, tune_batch_stats, _, _, tune_time = ml.train(
                 tune_X,
                 tune_Y,
                 ml.Mapper([geom.Losses.NRMSE], residual),
@@ -593,11 +697,12 @@ def tune_and_eval(
             )
         else:
             tuned_model_dprime = model_dprime
+            tune_time = 0
             tune_batch_stats = batch_stats
 
         if model_path:
             assert not model_path.is_file() or overwrite_save_model
-            ml.save(model_path, tuned_model_dprime)
+            ml.save_plus(model_path, tuned_model_dprime, {"train_time": tune_time})
 
     key, subkey = random.split(key)
     # (batch,losses)
@@ -619,7 +724,7 @@ def tune_and_eval(
         f"Tuned Loss rescale=True, D={test_X.D}: {smse_mean:.3e} +-{smse_std:.3e} ({rel_mean:.3f}% +-{rel_std:.3f}%)\n"
     )
 
-    return smse_mean, smse_std, rel_mean, rel_std
+    return smse_mean, smse_std, rel_mean, rel_std, convert_time + tune_time
 
 
 def handleArgs() -> argparse.Namespace:
@@ -628,7 +733,7 @@ def handleArgs() -> argparse.Namespace:
         "--n-tune-range",
         help="the number of data points in the tuning set",
         type=lambda s: tuple(int(x) for x in s.split(",")),
-        default="0,1,4,32,128",
+        default="0,1,4,8",
     )
     parser.add_argument(
         "--subsample", help="how much to subsample the trajectories", type=int, default=1
@@ -697,6 +802,7 @@ train_D = 2
 test_D = 3
 max_pixel_l1 = 2
 M = 5
+n_results = 5
 
 train_kwargs = {
     "residual": args.residual,
@@ -769,7 +875,7 @@ print("Define the models!")
 model_list_d = {}
 for D in full_D_range:
     key, subkey = random.split(key)
-    train_x0, train_xt, _, _, _, _ = get_data(
+    train_x0, train_xt, _, _, _, _, _ = get_data(
         D,
         args.N,
         args.diffusion_coef,
@@ -877,13 +983,11 @@ for D in full_D_range:
                     upsample_filters=upsample_filters_dict[D],
                     key=subkeys[2],
                 ),
-                "lr": {2: 1e-4, 3: 5e-3}[D],  # (D=2,1e-3) (D=3,5e-3)
-                # D=3, (n=1, 1e-4 or 5e-4) (n=4,1e-4)
+                "lr": 1e-4,
+                # D=3, for all of them (and tuning) its just 1e-4
                 **train_kwargs,
             },
             {  # tune and eval kwargs
-                # 4: could also be 5e-5 also
-                # 1: 1e-4, 4: 1e-4 (or 5e-5), 8:
                 "lr": 1e-4,
                 "rescale": geom.Rescaling.COMPAT_FLEX,
                 "conv_filters_dict": free_filters_dict,
@@ -897,7 +1001,7 @@ for D in full_D_range:
 # train the models, i.e. the warmstart lower dimensional models
 print("Train the models (warmstart)!")
 key, subkey = random.split(key)
-train_x0, train_xt, val_x0, val_xt, _, _ = get_data(
+train_x0, train_xt, val_x0, val_xt, _, _, pretrain_data_time = get_data(
     train_D,
     args.N,
     args.diffusion_coef,
@@ -912,7 +1016,15 @@ train_x0, train_xt, val_x0, val_xt, _, _ = get_data(
 
 train_data = (train_x0, train_xt, val_x0, val_xt)
 key, subkey = random.split(key)
-trained_model_list = train_all_models(train_data, subkey, model_list_d[train_D], lr_range, args)
+trained_model_list, train_times = train_all_models(
+    train_data, subkey, model_list_d[train_D], lr_range, args
+)
+train_times = np.array(train_times)[:, None]  # (models,1)
+# will want to re-run, but for now this is 2gpus, batch=8 1587.40561104 1gpu batch=8 1026.90299463
+train_times = np.array([1026.90299463]).reshape((1, 1))  # (models,1)
+# (models,n_results)
+train_times = np.concat([np.zeros((len(train_times), n_results - 1)), train_times], axis=1)
+print("train_times", train_times)
 
 if args.find_train_lr:
     exit()
@@ -924,7 +1036,7 @@ for n_tune in args.n_tune_range:
     print(f"D={test_D}, n_tune={n_tune}.\n")
     # the data is saved, so this is still reasonably efficient
     key, subkey = random.split(key)
-    tune_data = get_data(
+    *tune_data, tune_data_time = get_data(
         test_D,
         args.N,
         args.diffusion_coef,
@@ -961,7 +1073,7 @@ for n_tune in args.n_tune_range:
         subkey,
         lr_range if args.find_tune_lr else [],
         num_trials=args.n_trials,
-        num_results=4,  # smse_mean, smse_std, rel_mean, rel_std
+        num_results=n_results,  # smse_mean, smse_std, rel_mean, rel_std, train_time
         is_wandb=args.tune_wandb,
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
@@ -972,6 +1084,7 @@ for n_tune in args.n_tune_range:
             "train_or_tune": "tune",
         },
     )
+    baseline_results[..., -1] += tune_data_time
     results_dict[test_D].append(baseline_results)
 
     key, subkey = random.split(key)
@@ -982,7 +1095,7 @@ for n_tune in args.n_tune_range:
         subkey,
         lr_range if args.find_tune_lr else [],
         num_trials=args.n_trials,
-        num_results=4,  # smse_mean, smse_std, rel_mean, rel_std
+        num_results=n_results,  # smse_mean, smse_std, rel_mean, rel_std, train_time
         is_wandb=args.tune_wandb,
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
@@ -993,6 +1106,8 @@ for n_tune in args.n_tune_range:
             "train_or_tune": "tune",
         },
     )
+    tune_results += train_times[None, None]
+    tune_results[..., -1] += pretrain_data_time + tune_data_time
 
     results_dict[train_D].append(tune_results)
 
@@ -1005,3 +1120,5 @@ if args.images_dir is not None:
         model_names_d,
         args.images_dir,
     )
+
+    plot_time_results(results_dict, ["L2 Error", "Relative Error"], model_names_d, args.images_dir)

--- a/scripts/cfd_2d.py
+++ b/scripts/cfd_2d.py
@@ -307,7 +307,7 @@ def train_and_eval(
     if load_model is None:
         steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
         key, subkey = random.split(key)
-        model, batch_stats, train_loss, val_loss = ml.train(
+        model, batch_stats, train_loss, val_loss, _ = ml.train(
             train_X,
             train_Y,
             map_and_loss,

--- a/scripts/cfd_anyd.py
+++ b/scripts/cfd_anyd.py
@@ -227,7 +227,7 @@ def train_and_eval(
     if load_model is None:
         steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
         key, subkey = random.split(key)
-        trained_model, batch_stats, train_loss, val_loss = ml.train(
+        trained_model, batch_stats, train_loss, val_loss, _ = ml.train(
             train_X,
             train_Y,
             map_and_loss,

--- a/scripts/exploratory/gradient_sphere.py
+++ b/scripts/exploratory/gradient_sphere.py
@@ -276,7 +276,7 @@ def train_and_eval(
     if load_model is None:
         steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
         key, subkey = random.split(key)
-        model, batch_stats, train_loss, val_loss = ml.train(
+        model, batch_stats, train_loss, val_loss, _ = ml.train(
             train_X,
             train_Y,
             map_and_loss,

--- a/scripts/exploratory/heat_equation_apebench.py
+++ b/scripts/exploratory/heat_equation_apebench.py
@@ -336,7 +336,7 @@ def train_model(
 
     steps_per_epoch = int(math.ceil(train_X.get_L() / batch_size))
     key, subkey = random.split(key)
-    trained_model, _, _, _ = ml.train(
+    trained_model, _, _, _, _ = ml.train(
         train_X,
         train_Y,
         ml.Mapper([geom.Losses.SMSE], residual),
@@ -464,7 +464,7 @@ def tune_and_eval(
             # Now treat the trained_model_d as a warmstart and do some additional training
             key, subkey = random.split(key)
             steps_per_epoch = int(math.ceil(tune_X.get_L() / batch_size))
-            tuned_model_dprime, tune_batch_stats, _, _ = ml.train(
+            tuned_model_dprime, tune_batch_stats, _, _, _ = ml.train(
                 tune_X,
                 tune_Y,
                 ml.Mapper([geom.Losses.SMSE], residual),

--- a/scripts/gravity_field.py
+++ b/scripts/gravity_field.py
@@ -236,7 +236,7 @@ else:
         )
     )
     key, subkey = random.split(key)
-    model, _, train_loss, val_loss = ml.train(
+    model, _, train_loss, val_loss, _ = ml.train(
         train_X,
         train_Y,
         map_and_loss,

--- a/scripts/heat_equation.py
+++ b/scripts/heat_equation.py
@@ -4,6 +4,7 @@ import functools as ft
 import math
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
+import numpy as np
 import pathlib
 import time
 from typing import Callable
@@ -47,9 +48,9 @@ def heat_step(D: int, x0: jax.Array, t: float, k: float, is_torus: bool) -> jax.
     # (spatial_size,D)
     idxs = jnp.stack(jnp.meshgrid(*meshgrid_dims, indexing="ij"), axis=-1).reshape((-1, D))
     x1 = []
+    # Effectively batching this entire dataset runs out of memory
+    # It is possible there are more efficient ways of doing this.
     for i, idx in enumerate(idxs):
-        if (i % (len(idxs) // 10)) == 0:
-            print(f"{D},{batch}: {i}/{len(idxs)}")
         # (spatial_size,D)
         if is_torus:
             idxs_diff = jnp.abs(idxs - idx[None])
@@ -76,7 +77,7 @@ def get_data_d(
     batch: int,
     key: jax.Array,
     data_dir: pathlib.Path,
-) -> tuple[geom.MultiImage, geom.MultiImage]:
+) -> tuple[geom.MultiImage, geom.MultiImage, float]:
     """
     Get an input, output data pair of heat diffusion after t timestep, diffusion coefficient k.
     The initial data is uniform on the range 0 to max_temp.
@@ -103,22 +104,27 @@ def get_data_d(
     if batch == 0:
         x0 = jnp.zeros((batch,) + (N,) * D)
         xt = jnp.zeros((batch,) + (N,) * D)
+        generation_time = 0
     elif data_dir.is_file():
         dataset = jnp.load(data_dir, allow_pickle=True).item()
         x0 = dataset["x0"]
         xt = dataset["xt"]
+        generation_time = dataset["generation_time"] if "generation_time" in dataset else -1
     else:
+        print(f"Creating data {data_dir}...")
+        start_time = time.time()
         key, subkey = random.split(key)
         x0 = random.uniform(subkey, shape=(batch,) + (N,) * D, minval=-max_temp, maxval=max_temp)
         xt = heat_step(D, x0, t, k, is_torus)
+        generation_time = time.time() - start_time
 
-        print(f"saving at {data_dir}...")
-        jnp.save(data_dir, {"x0": x0, "xt": xt})
+        print(f"Finished in {generation_time} seconds.")
+        jnp.save(data_dir, {"x0": x0, "xt": xt, "generation_time": generation_time})
 
     x0_img = geom.MultiImage({(0, 0): x0[:, None]}, D, is_torus)
     xt_img = geom.MultiImage({(0, 0): xt[:, None]}, D, is_torus)
 
-    return x0_img, xt_img
+    return x0_img, xt_img, generation_time
 
 
 def get_data(
@@ -138,6 +144,7 @@ def get_data(
     geom.MultiImage,
     geom.MultiImage,
     geom.MultiImage,
+    float,
 ]:
     """
     Get an input, output data pair of heat diffusion after 1 timestep, specified diffusion constant.
@@ -162,15 +169,15 @@ def get_data(
     data_dir_path = pathlib.Path(data_dir)
 
     key, subkey1, subkey2, subkey3 = random.split(key, num=4)
-    train_x0, train_xt = get_data_d(
+    train_x0, train_xt, train_generation_time = get_data_d(
         D, N, is_torus, diffusion_coef, t, max_temp, n_train, subkey1, data_dir_path / "train"
     )
 
-    val_x0, val_xt = get_data_d(
+    val_x0, val_xt, _ = get_data_d(
         D, N, is_torus, diffusion_coef, t, max_temp, n_val, subkey2, data_dir_path / "val"
     )
 
-    test_x0, test_xt = get_data_d(
+    test_x0, test_xt, _ = get_data_d(
         D, N, is_torus, diffusion_coef, t, max_temp, n_test, subkey3, data_dir_path / "test"
     )
     if n_test > 0:
@@ -179,7 +186,7 @@ def get_data(
         xt_resid_std = jnp.std(test_xt[((), 0)] - test_x0[((), 0)])
         print(f"D={D}, x0:{x0_std:.3e}, xt:{xt_std:.3e}, xt_resid:{xt_resid_std:.3e}")
 
-    return train_x0, train_xt, val_x0, val_xt, test_x0, test_xt
+    return train_x0, train_xt, val_x0, val_xt, test_x0, test_xt, train_generation_time
 
 
 def plot_multi_image(
@@ -373,7 +380,94 @@ def plot_results(
             ax.set_title(f"Test D={test_D} {ylabel}")
 
     plt.tight_layout()
-    plt.savefig(f"{saveloc}warmstart_plot.png")
+    plt.savefig(f"{saveloc}heat_warmstart_plot.png")
+    plt.close()
+
+
+def plot_time_results(
+    results_dict: dict[int, dict[int, list[jax.Array]]],
+    results_labels: list[str],
+    model_names_d: dict[int, list[str]],
+    saveloc: str,
+) -> None:
+    """
+    Plot the results of each model versus the time it took to get those results, including the time
+    to generate the training data.
+
+    args:
+        results_dict: The results dict of test_D, train_D, then a list over n_tune, array n_results
+            in this case n_results is smse_mean, smse_std, rel_mean, rel_std
+        results_labels: e.g. 'l2', 'relative error'
+        model_names_d: model names for each dimension
+        saveloc: beginning of save location
+
+    returns:
+        none
+    """
+    # group the results by model, across all trained dimensions
+    grouped_results = {}
+    for test_D, results_train_d in results_dict.items():
+        grouped_results[test_D] = {}
+        for train_D, results in results_train_d.items():
+            for i, name in enumerate(model_names_d[train_D]):
+                name_trimmed = name[:-3]  # this assumes that all models end in _D1, _D2, or _D3
+                display_name = f"{name} (baseline)" if train_D == test_D else name
+
+                if name_trimmed in grouped_results[test_D]:
+                    # (n_tune,n_trials,n_results)
+                    grouped_results[test_D][name_trimmed].append(
+                        (display_name, jnp.stack(results)[:, :, 0, i])
+                    )
+                else:
+                    grouped_results[test_D][name_trimmed] = [
+                        (display_name, jnp.stack(results)[:, :, 0, i])
+                    ]
+
+    # figsize is 8 per col, 6 per row, (cols,rows)
+    nrows = len(list(grouped_results.keys()))
+    ncols = len(results_labels)
+    _, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(8 * ncols, 6 * nrows))
+    linestyles = ["solid", "dotted", "dashed", "dashdot"]
+    colors = ["b", "g", "r", "c", "m", "y"]
+
+    axes = [axes] if nrows == 1 else axes
+
+    for (test_D, results_by_model), ax_row in zip(grouped_results.items(), axes):
+        for error_idx, ylabel, ax in zip(range(len(results_labels)), results_labels, ax_row):
+            assert isinstance(ax, Axes)
+
+            # looping over 'two_layer_gaussian', 'resnet_equiv_42', ...
+            for i, model_results in enumerate(results_by_model.values()):
+                for j, (display_name, results_arr) in enumerate(model_results):
+
+                    # mean is over trials
+                    times = jnp.mean(results_arr, axis=1)[:, -1] / 60
+                    mean_result = jnp.mean(results_arr, axis=1)[:, error_idx * 2]
+                    stdev = jnp.mean(results_arr, axis=1)[:, error_idx * 2 + 1]
+                    ax.plot(
+                        times,
+                        mean_result,
+                        marker="o",
+                        linestyle=linestyles[j],
+                        label=display_name,
+                        color=colors[j],  # was i, currently only model
+                    )
+                    ax.fill_between(
+                        times,
+                        mean_result - stdev,
+                        mean_result + stdev,
+                        color=colors[j],
+                        alpha=0.2,
+                    )
+
+            ax.legend()
+            ax.set_xlabel("Total time (minutes)")
+            ax.set_ylabel(ylabel)
+            ax.set_yscale("log")
+            ax.set_title(f"Test D={test_D} {ylabel}")
+
+    plt.tight_layout()
+    plt.savefig(f"{saveloc}heat_warmstart_time_plot.png")
     plt.close()
 
 
@@ -397,7 +491,7 @@ def train_model(
     has_aux: bool = False,
     verbose: int = 1,
     is_wandb: bool = False,
-) -> models.MultiImageModule:
+) -> tuple[models.MultiImageModule, float]:
     train_X, train_Y, val_X, val_Y = data
     N = train_X.get_spatial_dims()[0]
     batch_stats = eqx.nn.State(model) if has_aux else None
@@ -407,11 +501,12 @@ def train_model(
     print(f"{model_name_extended} params: {models.count_params(model):,}")
 
     if model_path and model_path.is_file() and not overwrite_save_model:
-        return ml.load(model_path, model)
+        trained_model, further_args = ml.load_plus(model_path, model)
+        return trained_model, further_args["train_time"]
 
     steps_per_epoch = int(math.ceil(train_X.get_L() / batch_size))
     key, subkey = random.split(key)
-    trained_model, _, _, _ = ml.train(
+    trained_model, _, _, _, train_time = ml.train(
         train_X,
         train_Y,
         ml.Mapper([geom.Losses.SMSE], residual),
@@ -435,9 +530,9 @@ def train_model(
     if model_path:
         assert not model_path.is_file() or overwrite_save_model
         # TODO: need to save batch_stats as well
-        ml.save(model_path, trained_model)
+        ml.save_plus(model_path, trained_model, {"train_time": train_time})
 
-    return trained_model
+    return trained_model, train_time
 
 
 def train_all_models(
@@ -483,9 +578,9 @@ def train_all_models(
                 },
             )
         else:
-            trained_model = train_model(data, subkey, model_name, **_train_kwargs)
+            trained_model, train_time = train_model(data, subkey, model_name, **_train_kwargs)
             _test_kwargs = {**_test_kwargs, "model": trained_model}
-            trained_models.append((model_name, tune_and_eval, _test_kwargs))
+            trained_models.append((model_name, tune_and_eval, _test_kwargs, train_time))
 
     return trained_models
 
@@ -515,7 +610,7 @@ def tune_and_eval(
     has_aux: bool = False,
     verbose: int = 1,
     is_wandb: bool = False,
-) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, float]:
     tune_X, tune_Y, val_X, val_Y, test_X, test_Y = data
     N = tune_X.get_spatial_dims()[0]
     batch_stats = eqx.nn.State(model) if has_aux else None
@@ -524,28 +619,32 @@ def tune_and_eval(
     key, subkey = random.split(key)
     # rescale set to True, small but notable difference
     if conv_filters_dict is not None and rescale is not None:
+        start_time = time.time()
         model_dprime = model.convertD(
             conv_filters_dict[tune_X.D],
             rescale,
             subkey,
             upsample_filters=upsample_filters_dict[tune_X.D] if upsample_filters_dict else None,
         )
+        convert_time = time.time() - start_time  # this should be tiny
         model_name_extended += f"_rescale{rescale.name}"
     else:
+        convert_time = 0.0
         model_dprime = model
 
     model_path = model_dir / f"{model_name_extended}_model.eqx" if model_dir else None
     print(f"tuning: {model_name_extended}")
 
     if model_path and model_path.is_file() and not overwrite_save_model:
-        tuned_model_dprime = ml.load(model_path, model_dprime)
+        tuned_model_dprime, further_args = ml.load_plus(model_path, model_dprime)
         tune_batch_stats = batch_stats
+        tune_time = further_args["train_time"]
     else:
         if tune_X.get_L() > 0:
             # Now treat the trained_model_d as a warmstart and do some additional training
             key, subkey = random.split(key)
             steps_per_epoch = int(math.ceil(tune_X.get_L() / batch_size))
-            tuned_model_dprime, tune_batch_stats, _, _ = ml.train(
+            tuned_model_dprime, tune_batch_stats, _, _, tune_time = ml.train(
                 tune_X,
                 tune_Y,
                 ml.Mapper([geom.Losses.SMSE], residual),
@@ -567,11 +666,12 @@ def tune_and_eval(
             )
         else:
             tuned_model_dprime = model_dprime
+            tune_time = 0
             tune_batch_stats = batch_stats
 
         if model_path:
             assert not model_path.is_file() or overwrite_save_model
-            ml.save(model_path, tuned_model_dprime)
+            ml.save_plus(model_path, tuned_model_dprime, {"train_time": tune_time})
 
     key, subkey = random.split(key)
     # (batch,losses)
@@ -605,7 +705,7 @@ def tune_and_eval(
     #         "heat",
     #     )
 
-    return smse_mean, smse_std, rel_mean, rel_std
+    return smse_mean, smse_std, rel_mean, rel_std, convert_time + tune_time
 
 
 # an example of currently used script
@@ -689,6 +789,7 @@ lr_range = [1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 5e-3, 1e-2, 5e-2]
 
 max_pixel_l1 = 2
 M = 5
+n_results = 5
 
 train_kwargs = {
     "residual": args.residual,
@@ -772,7 +873,7 @@ print("Define the models!")
 model_list_d = {}
 for D in full_D_range:
     key, subkey = random.split(key)
-    train_x0, train_xt, _, _, _, _ = get_data(
+    train_x0, train_xt, _, _, _, _, _ = get_data(
         D, args.N, True, args.diffusion_coef, args.n_train, 0, 0, subkey, args.data
     )
     input_keys = train_x0.get_signature()
@@ -996,9 +1097,10 @@ for D in full_D_range:
 # train the models, i.e. the warmstart lower dimensional models
 print("Train the models (warmstart)!")
 trained_model_list_d = {}
+pretrain_data_time_d = {}
 for train_D in args.train_D_range:
     key, subkey = random.split(key)
-    train_x0, train_xt, val_x0, val_xt, _, _ = get_data(
+    train_x0, train_xt, val_x0, val_xt, _, _, pretrain_data_time = get_data(
         train_D, args.N, True, args.diffusion_coef, args.n_train, args.n_val, 0, subkey, args.data
     )
 
@@ -1007,6 +1109,7 @@ for train_D in args.train_D_range:
     trained_model_list_d[train_D] = train_all_models(
         train_data, subkey, model_list_d[train_D], lr_range, args
     )
+    pretrain_data_time_d[train_D] = pretrain_data_time
 
 if args.find_train_lr:
     exit()
@@ -1020,7 +1123,7 @@ for test_D in args.test_D_range:
         print(f"D={test_D}, n_tune={n_tune}.\n")
         # the data is saved, so this is still reasonably efficient
         key, subkey = random.split(key)
-        tune_data = get_data(
+        *tune_data, tune_data_time = get_data(
             test_D,
             args.N,
             True,
@@ -1057,7 +1160,7 @@ for test_D in args.test_D_range:
             subkey,
             lr_range if args.find_tune_lr else [],
             num_trials=args.n_trials,
-            num_results=4,  # smse_mean, smse_std, rel_mean, rel_std
+            num_results=n_results,  # smse_mean, smse_std, rel_mean, rel_std, tune_time
             is_wandb=args.tune_wandb,
             wandb_project=args.wandb_project,
             wandb_entity=args.wandb_entity,
@@ -1068,6 +1171,7 @@ for test_D in args.test_D_range:
                 "train_or_tune": "tune",
             },
         )
+        baseline_results[..., -1] += tune_data_time
         results_dict[test_D][test_D].append(baseline_results)
 
         for train_D in args.train_D_range:
@@ -1077,8 +1181,15 @@ for test_D in args.test_D_range:
             # select the correct learning rate for the tuning based on train and test dimensions
             trained_model_list = [
                 (name, func, {**_test_kwargs, "lr": _test_kwargs["lr"][(train_D, test_D)][n_tune]})
-                for name, func, _test_kwargs in trained_model_list_d[train_D]
+                for name, func, _test_kwargs, _ in trained_model_list_d[train_D]
             ]
+            train_model_times = np.stack(
+                [train_time for _, _, _, train_time in trained_model_list_d[train_D]]
+            )
+            train_model_times = np.concat(
+                [np.zeros((len(train_model_times), n_results - 1)), train_model_times[:, None]],
+                axis=1,
+            )
 
             key, subkey = random.split(key)
             # (n_trials, benchmark, models, n_results)
@@ -1088,7 +1199,7 @@ for test_D in args.test_D_range:
                 subkey,
                 lr_range if args.find_tune_lr else [],
                 num_trials=args.n_trials,
-                num_results=4,  # smse_mean, smse_std, rel_mean, rel_std
+                num_results=n_results,  # smse_mean, smse_std, rel_mean, rel_std, tune_time
                 is_wandb=args.tune_wandb,
                 wandb_project=args.wandb_project,
                 wandb_entity=args.wandb_entity,
@@ -1099,6 +1210,9 @@ for test_D in args.test_D_range:
                     "train_or_tune": "tune",
                 },
             )
+
+            tune_results += train_model_times[None, None]
+            tune_results[..., -1] += pretrain_data_time_d[train_D] + tune_data_time
 
             results_dict[test_D][train_D].append(tune_results)
 
@@ -1112,3 +1226,5 @@ if args.images_dir is not None:
         model_names_d,
         args.images_dir,
     )
+
+    plot_time_results(results_dict, ["L2 Error", "Relative Error"], model_names_d, args.images_dir)

--- a/scripts/shallow_water.py
+++ b/scripts/shallow_water.py
@@ -595,7 +595,7 @@ def train_and_eval(
     if load_model is None:
         steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
         key, subkey = random.split(key)
-        model, batch_stats, train_loss, val_loss = ml.train(
+        model, batch_stats, train_loss, val_loss, _ = ml.train(
             train_X,
             train_Y,
             map_and_loss_f,

--- a/scripts/supernova.py
+++ b/scripts/supernova.py
@@ -278,7 +278,7 @@ def train_and_eval(
     if load_model is None:
         key, subkey = random.split(key)
         steps_per_epoch = int(np.ceil(train_X.get_L() / batch_size))
-        model, batch_stats, train_loss, val_loss = ml.train(
+        model, batch_stats, train_loss, val_loss, _ = ml.train(
             train_X,
             train_Y,
             map_and_loss,

--- a/scripts/wave_anyd.py
+++ b/scripts/wave_anyd.py
@@ -346,7 +346,7 @@ def train_model(
     else:
         steps_per_epoch = int(math.ceil(train_X.get_L() / batch_size))
         key, subkey = random.split(key)
-        trained_model, _, _, _ = ml.train(
+        trained_model, _, _, _, _ = ml.train(
             train_X,
             train_Y,
             ml.Mapper([geom.Losses.SMSE], residual, eps=1e-5),
@@ -491,7 +491,7 @@ def tune_and_eval(
             # Now treat the trained_model_d as a warmstart and do some additional training
             key, subkey = random.split(key)
             steps_per_epoch = int(math.ceil(tune_X.get_L() / batch_size))
-            tuned_model_dprime, tune_batch_stats, _, _ = ml.train(
+            tuned_model_dprime, tune_batch_stats, _, _, _ = ml.train(
                 tune_X,
                 tune_Y,
                 ml.Mapper([geom.Losses.SMSE], residual, eps=1e-5),

--- a/src/ginjax/ml/training.py
+++ b/src/ginjax/ml/training.py
@@ -1,5 +1,6 @@
 import time
 import enum
+import json
 import math
 import functools
 import pathlib
@@ -34,6 +35,24 @@ def save(filename: str | pathlib.Path, model: models.MultiImageModule) -> None:
         eqx.tree_serialise_leaves(f, model)
 
 
+def save_plus(
+    filename: str | pathlib.Path, model: models.MultiImageModule, further_args: dict = {}
+) -> None:
+    """
+    New version of save, allows you to save any serializable args.
+
+    args:
+        filename: the file to save the model to
+        model: the model to save
+        further_args: more values to save, as a dictionary
+    """
+    # TODO: save batch stats
+    with open(filename, "wb") as f:
+        further_args_str = json.dumps(further_args)
+        f.write((further_args_str + "\n").encode())
+        eqx.tree_serialise_leaves(f, model)
+
+
 def load(filename: str | pathlib.Path, model: models.MultiImageModule) -> models.MultiImageModule:
     """
     Load an equinox model.
@@ -47,6 +66,24 @@ def load(filename: str | pathlib.Path, model: models.MultiImageModule) -> models
     """
     with open(filename, "rb") as f:
         return eqx.tree_deserialise_leaves(f, model)
+
+
+def load_plus(
+    filename: str | pathlib.Path, model: models.MultiImageModule
+) -> tuple[models.MultiImageModule, dict]:
+    """
+    Load an equinox model.
+
+    args:
+        filename: the file to load the model from
+        model: the type of model we are loading, the parameter values will be set to the loaded ones
+
+    returns:
+        the loaded model
+    """
+    with open(filename, "rb") as f:
+        further_args = json.loads(f.readline().decode())
+        return eqx.tree_deserialise_leaves(f, model), further_args
 
 
 ## Data and Batching operations
@@ -427,9 +464,7 @@ def train(
     devices: Optional[list[jax.Device]] = None,
     aux_data: Optional[eqx.nn.State] = None,
     is_wandb: bool = False,
-) -> tuple[
-    models.MultiImageModule, Optional[eqx.nn.State], Optional[ArrayLike], Optional[ArrayLike]
-]:
+) -> tuple[models.MultiImageModule, eqx.nn.State | None, ArrayLike | None, ArrayLike | None, float]:
     """
     Method to train the model. It uses stochastic gradient descent (SGD) with the optimizer to learn the
     parameters the minimize the map_and_loss function. The model is returned. This function automatically
@@ -457,7 +492,7 @@ def train(
         is_wandb: whether wandb experiment tracking has been initiated and should be logged to
 
     returns:
-        A tuple of best model in inference mode, aux_data, epoch loss, and val loss
+        A tuple of best model in inference mode, aux_data, epoch loss, val loss, and train_time
     """
     if isinstance(stop_condition, ValLoss) and not (validation_X and validation_Y):
         raise ValueError("Stop condition is ValLoss, but no validation data provided.")
@@ -467,6 +502,7 @@ def train(
 
     devices = devices if devices else jax.devices()
 
+    total_train_time = 0
     opt_state = optimizer.init(eqx.filter(model, eqx.is_array))
     epoch = 0
     epoch_val_loss = None
@@ -475,10 +511,10 @@ def train(
     epoch_time = 0
     stop_condition.best_model = model
     while not stop_condition.stop(model, epoch, epoch_loss, epoch_val_loss, epoch_time):
+        start_time = time.time()
         rand_key, subkey = random.split(rand_key)
         X_batches, Y_batches = get_batches((X, Y), batch_size, subkey, devices)
         epoch_loss = None
-        start_time = time.time()
         for X_batch, Y_batch in zip(X_batches, Y_batches):
             model, opt_state, loss_value, aux_data = train_step(
                 map_and_loss,
@@ -490,6 +526,8 @@ def train(
                 aux_data,
             )
             epoch_loss = loss_value if epoch_loss is None else epoch_loss + loss_value
+
+        total_train_time += time.time() - start_time
 
         if epoch_loss is not None:
             epoch_loss = epoch_loss / len(X_batches)
@@ -520,7 +558,7 @@ def train(
 
         epoch_time = time.time() - start_time
 
-    return stop_condition.best_model, aux_data, epoch_loss, val_loss
+    return stop_condition.best_model, aux_data, epoch_loss, val_loss, total_train_time
 
 
 BENCHMARK_DATA = "benchmark_data"


### PR DESCRIPTION
## Changes
- track train_time in ml.train. This is the time of the function spent training, and does not include validation time
- update everywhere that calls ml.train
- add hardcoded data generation times to burgers_anyd data generation since I can't save it
- add a plot_time_results to burgers plotting
- add data generation time to heat_equation
- make the save_plus and load_plus methods of model saving which is able to save metadata. Feels a little hacky because in some cases I would like this metadata to live on the model, but equinox models are immutable which makes it a pain

## Changes
- run heat_equation
- run burgers_anyd

## Doc Changes
- none