### PR TITLE
swap definitions of nrmse so its more stable

### DIFF
--- a/scripts/anyd_helpers.py
+++ b/scripts/anyd_helpers.py
@@ -575,7 +575,7 @@ def tune_and_eval(
             tuned_model_dprime, tune_batch_stats, _, _, tune_time = ml.train(
                 tune_X,
                 tune_Y,
-                ml.Mapper([train_loss_f], residual),
+                ml.Mapper([train_loss_f], residual, eps=1e-9),
                 model_dprime,
                 subkey,
                 stop_condition=ml.EpochStop(epochs, verbose=verbose),
@@ -588,7 +588,7 @@ def tune_and_eval(
                 ),
                 validation_X=val_X,
                 validation_Y=val_Y,
-                val_map_and_loss=ml.Mapper([geom.Losses.NRMSE], residual, eps=1e-5),
+                val_map_and_loss=ml.Mapper([geom.Losses.NRMSE], residual, eps=1e-9),
                 aux_data=batch_stats,
                 is_wandb=is_wandb,
             )
@@ -604,7 +604,7 @@ def tune_and_eval(
     key, subkey = random.split(key)
     # (batch,losses)
     tuned_loss = ml.map_loss_in_batches(
-        ml.Mapper([geom.Losses.L2_REL, geom.Losses.SMSE], residual, reduce=None),
+        ml.Mapper([geom.Losses.L2_REL, geom.Losses.SMSE], residual, reduce=None, eps=1e-9),
         tuned_model_dprime,
         test_X,
         test_Y,

--- a/scripts/cfd_anyd.py
+++ b/scripts/cfd_anyd.py
@@ -70,6 +70,7 @@ def get_data(
     float,
 ]:
     """
+    TODO: maybe I can load data as needed? one batch at a time? probably needed for 3d data
     Get data of a particular dimension from a preset list of files in the specified folder.
 
     args:
@@ -216,7 +217,7 @@ test_D = 3
 n_results = 5
 
 train_kwargs = {
-    "train_loss_f": geom.Losses.SMSE,
+    "train_loss_f": geom.Losses.NRMSE,
     "residual": False,
     "batch_size": args.batch,
     "epochs": args.epochs,
@@ -228,7 +229,7 @@ train_kwargs = {
 }
 
 test_kwargs = {
-    "train_loss_f": geom.Losses.SMSE,
+    "train_loss_f": geom.Losses.NRMSE,
     "residual": False,
     "batch_size": args.batch,
     "epochs": args.epochs,
@@ -266,7 +267,7 @@ print("Define the models!")
 model_list_d = {}
 for D in full_D_range:
     key, subkey = random.split(key)
-    train_x0, train_xt, _, _, _, _, _ = get_data(D, args.n_train, 0, 0, args.past_steps, args.data)
+    train_x0, train_xt, _, _, _, _, _ = get_data(D, 1, 0, 0, args.past_steps, args.data)
     input_keys = train_x0.get_signature()
     output_keys = train_xt.get_signature()
 

--- a/src/ginjax/geometric/constants.py
+++ b/src/ginjax/geometric/constants.py
@@ -34,7 +34,9 @@ class Rescaling(enum.Enum):
 class Losses(enum.Enum):
     SMSE = enum.auto()
     NRMSE = enum.auto()
+    NRMSE_PER_PIXEL = enum.auto()
     L2_REL = enum.auto()
+    L2_REL_PER_PIXEL = enum.auto()
 
 
 class KroneckerDeltaSymbol:

--- a/src/ginjax/ml/losses.py
+++ b/src/ginjax/ml/losses.py
@@ -124,14 +124,14 @@ def normalized_smse_loss(
     return jnp.mean(order_loss) if reduce == "mean" else order_loss
 
 
-def nrmse_loss(
+def nrmse_per_pixel_loss(
     multi_image_x: geom.MultiImage,
     multi_image_y: geom.MultiImage,
     reduce: str | None = "mean",
     eps: float = 0,
 ) -> jax.Array:
     """
-    The normalized root mean squared error. The error is relative to the second input.
+    The normalized root mean squared error. The error is relative to the second input per pixel.
 
     The average is taken over each pixel, and channel. If reduce is 'mean' it is also
     taken over the batch.
@@ -159,11 +159,58 @@ def nrmse_loss(
     for image_a, image_b in zip(multi_image_x.values(), multi_image_y.values()):
         diff_norm = geom.norm(D + 2, image_a - image_b)  # (batch,channels,spatial)
         image_b_norm = geom.norm(D + 2, image_b)  # (batch,channels,spatial)
-        rel_error = jnp.where(image_b_norm == 0.0, 0.0, diff_norm / (image_b_norm + eps))
+        rel_error = diff_norm / (image_b_norm + eps)
         # (batch,channels*spatial)
         error_per_batch = jnp.concatenate([error_per_batch, rel_error.reshape((batch, -1))], axis=1)
 
     error_per_batch = jnp.mean(error_per_batch, axis=1)  # mean over channels, spatial -> (batch,)
+
+    return jnp.mean(error_per_batch) if reduce == "mean" else error_per_batch
+
+
+def nrmse_loss(
+    multi_image_x: geom.MultiImage,
+    multi_image_y: geom.MultiImage,
+    reduce: str | None = "mean",
+    eps: float = 0,
+) -> jax.Array:
+    """
+    The normalized root mean squared error. This definition follows the standard one used in
+    literature where the norm is taken over the entire difference image and reference image
+    before doing the division diff / reference. We then take the mean over the image types,
+    and then reduce over the batch.
+
+    args:
+        multi_image_x: predicted data, image_blocks are shape (batch,channels,spatial,tensor)
+        multi_image_y: target data, image_blocks are shape (batch,channels,spatial,tensor)
+        reduce: how to reduce over batch. Either "mean" or None.
+        eps: epsilon to add to the denominator to avoid divide by zero errors
+
+    returns:
+        average root mean squared error with respect to the second input.
+    """
+    reduce_options = {"mean", None}
+    assert (
+        reduce in reduce_options
+    ), f"l1_rel_error: reduce={reduce} must be one of {reduce_options}"
+    assert (
+        multi_image_x.get_n_leading() == multi_image_y.get_n_leading() == 2
+    ), "l1_rel_error: MultiImages must have batch and channel axes"
+
+    batch = multi_image_x.get_L()
+    D = multi_image_x.D
+
+    error_per_batch = jnp.zeros((batch, 0))
+    for image_a, image_b in zip(multi_image_x.values(), multi_image_y.values()):
+        diff_norms = jnp.linalg.norm(
+            image_a.reshape((batch, -1)) - image_b.reshape((batch, -1)), axis=1, keepdims=True
+        )
+        target_norms = jnp.linalg.norm(image_b.reshape((batch, -1)), axis=1, keepdims=True)
+        error_per_batch = jnp.concatenate(
+            [error_per_batch, diff_norms / (target_norms + eps)], axis=1
+        )
+
+    error_per_batch = jnp.mean(error_per_batch, axis=1)  # mean over tensor types -> (batch,)
 
     return jnp.mean(error_per_batch) if reduce == "mean" else error_per_batch
 
@@ -175,7 +222,30 @@ def l2_rel_error(
     eps: float = 0,
 ) -> jax.Array:
     """
-    Average per tensor relative error as a percentage. The error is relative to the second input.
+    The relative error, taken as a norm over the entire difference image divided by the norm over
+    the entire reference image. We then take the mean over the image types, and then reduce over
+    the batch.
+
+    args:
+        multi_image_x: predicted data, image_blocks are shape (batch,channels,spatial,tensor)
+        multi_image_y: target data, image_blocks are shape (batch,channels,spatial,tensor)
+        reduce: how to reduce over batch. Either "mean" or None.
+        eps: epsilon to add to the denominator to avoid divide by zero errors
+
+    returns:
+        average percent relative error with respect to the second input.
+    """
+    return nrmse_loss(multi_image_x, multi_image_y, reduce, eps) * 100  # convert to percent
+
+
+def l2_per_pixel_rel_error(
+    multi_image_x: geom.MultiImage,
+    multi_image_y: geom.MultiImage,
+    reduce: str | None = "mean",
+    eps: float = 0,
+) -> jax.Array:
+    """
+    Average per tensor relative error as a percentage. The error is relative to the second input per pixel.
 
     The average is taken over each pixel, and channel. If reduce is 'mean' it is also
     taken over the batch.
@@ -189,4 +259,6 @@ def l2_rel_error(
     returns:
         average percent relative error with respect to the second input.
     """
-    return nrmse_loss(multi_image_x, multi_image_y, reduce, eps) * 100  # convert to percent
+    return (
+        nrmse_per_pixel_loss(multi_image_x, multi_image_y, reduce, eps) * 100
+    )  # convert to percent

--- a/src/ginjax/ml/losses.py
+++ b/src/ginjax/ml/losses.py
@@ -177,7 +177,7 @@ def nrmse_loss(
     """
     The normalized root mean squared error. This definition follows the standard one used in
     literature where the norm is taken over the entire difference image and reference image
-    before doing the division diff / reference. We then take the mean over the image types,
+    before doing the division diff / reference. We then take the mean over the channels,
     and then reduce over the batch.
 
     args:
@@ -198,19 +198,19 @@ def nrmse_loss(
     ), "l1_rel_error: MultiImages must have batch and channel axes"
 
     batch = multi_image_x.get_L()
-    D = multi_image_x.D
 
     error_per_batch = jnp.zeros((batch, 0))
     for image_a, image_b in zip(multi_image_x.values(), multi_image_y.values()):
-        diff_norms = jnp.linalg.norm(
-            image_a.reshape((batch, -1)) - image_b.reshape((batch, -1)), axis=1, keepdims=True
-        )
-        target_norms = jnp.linalg.norm(image_b.reshape((batch, -1)), axis=1, keepdims=True)
+        # reshape to (batch,channels,spatial*tensor)
+        image_a = image_a.reshape(image_a.shape[:2] + (-1,))
+        image_b = image_b.reshape(image_b.shape[:2] + (-1,))
+        diff_norms = jnp.linalg.norm(image_a - image_b, axis=2)
+        target_norms = jnp.linalg.norm(image_b, axis=2)
         error_per_batch = jnp.concatenate(
             [error_per_batch, diff_norms / (target_norms + eps)], axis=1
         )
 
-    error_per_batch = jnp.mean(error_per_batch, axis=1)  # mean over tensor types -> (batch,)
+    error_per_batch = jnp.mean(error_per_batch, axis=1)  # (batch,channels) -> (batch,)
 
     return jnp.mean(error_per_batch) if reduce == "mean" else error_per_batch
 

--- a/src/ginjax/ml/training.py
+++ b/src/ginjax/ml/training.py
@@ -18,7 +18,13 @@ import optax
 
 import ginjax.geometric as geom
 from ginjax.ml.stopping_conditions import StopCondition, ValLoss
-from ginjax.ml.losses import smse_loss, nrmse_loss, l2_rel_error
+from ginjax.ml.losses import (
+    smse_loss,
+    nrmse_loss,
+    nrmse_per_pixel_loss,
+    l2_rel_error,
+    l2_per_pixel_rel_error,
+)
 import ginjax.models as models
 
 
@@ -728,6 +734,7 @@ class Mapper:
     losses: list[geom.Losses]
     residual: bool
     reduce: str | None
+    eps: float
 
     def __init__(
         self: Self,
@@ -794,8 +801,16 @@ class Mapper:
                 loss_outputs.append(smse_loss(pred_y, multi_image_y, self.reduce))
             elif loss is geom.Losses.NRMSE:
                 loss_outputs.append(nrmse_loss(pred_y, multi_image_y, self.reduce, eps=self.eps))
+            elif loss is geom.Losses.NRMSE_PER_PIXEL:
+                loss_outputs.append(
+                    nrmse_per_pixel_loss(pred_y, multi_image_y, self.reduce, eps=self.eps)
+                )
             elif loss is geom.Losses.L2_REL:
                 loss_outputs.append(l2_rel_error(pred_y, multi_image_y, self.reduce, eps=self.eps))
+            elif loss is geom.Losses.L2_REL_PER_PIXEL:
+                loss_outputs.append(
+                    l2_per_pixel_rel_error(pred_y, multi_image_y, self.reduce, eps=self.eps)
+                )
 
         # if we aren't reducing the batch dimension, we don't want to squeeze it out
         loss_outputs = jnp.stack(loss_outputs, axis=-1)


### PR DESCRIPTION
## Changes
- use 1e-9 for nrmse epsilon
- swap cfd_anyd to use nrmse as the train loss
- move old nrmse to nrmse_per_pixel because the relative error is on a per pixel basis
- new nrmse calculates the rmse over the entire image, then divides by the norm of the entire reference image, before taking the mean over channels (and possibly batch). this is more stable during training, doesn't result in NaNs.

## Testing
- run the cfd_anyd script
- will have to re-run burgers in the future, because the loss is now different

## Doc Changes
- none