### PR TITLE
Cfd tuning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "numpy>=2.2.2",
     "optax>=0.2.4",
     "wandb>=0.19.0",
+    "torch",
 ]
 
 [project.optional-dependencies]

--- a/scripts/anyd_helpers.py
+++ b/scripts/anyd_helpers.py
@@ -12,6 +12,7 @@ import jax.numpy as jnp
 from jax import random
 import equinox as eqx
 import optax
+from torch.utils.data import DataLoader
 
 import ginjax.geometric as geom
 from ginjax import models
@@ -325,13 +326,7 @@ def plot_time_results(
 
 
 def train_model(
-    data: tuple[
-        geom.MultiImage,
-        geom.MultiImage,
-        geom.MultiImage,
-        geom.MultiImage,
-    ],
-    key: jax.Array,
+    data: tuple[DataLoader[ml.MultiImageDataset], DataLoader[ml.MultiImageDataset]],
     model_name: str,
     model: models.AnyDimensionalModel,
     lr: float,
@@ -350,8 +345,7 @@ def train_model(
     Train the model.
 
     args:
-        data: input and output multi image pairs of train and val data
-        key: key for randomness
+        data: train and val dataloaders as a tuple
         model_name: name of the model we are training
         model: the any dimensional model to train
         lr: learning rate
@@ -367,10 +361,14 @@ def train_model(
         verbose: verbosity level for training
         is_wandb: whether to turn on wandb tracking
     """
-    train_X, train_Y, val_X, val_Y = data
-    N = train_X.get_spatial_dims()[0]
+    train_dataloader, val_dataloader = data
+    assert isinstance(train_dataloader.dataset, ml.MultiImageDataset)
+
+    D = train_dataloader.dataset.D
+    L = len(train_dataloader.dataset)
+    N = train_dataloader.dataset.get_N()
     batch_stats = eqx.nn.State(model) if has_aux else None
-    model_name_extended = f"{model_name}_L{train_X.get_L()}_N{N}_e{epochs}"
+    model_name_extended = f"{model_name}_L{L}_N{N}_e{epochs}"
     model_path = model_dir / f"{model_name_extended}_model.eqx" if model_dir else None
 
     print(f"{model_name_extended} params: {models.count_params(model):,}")
@@ -379,24 +377,19 @@ def train_model(
         trained_model, further_args = ml.load_plus(model_path, model)
         train_time = further_args["train_time"]
     else:
-        steps_per_epoch = int(math.ceil(train_X.get_L() / batch_size))
-        key, subkey = random.split(key)
-        trained_model, _, _, _, train_time = ml.train(
-            train_X,
-            train_Y,
+        steps_per_epoch = int(math.ceil(L / batch_size))
+        trained_model, _, _, _, train_time = ml.train_dl(
+            train_dataloader,
             ml.Mapper([train_loss_f], residual),
             model,
-            subkey,
             stop_condition=ml.EpochStop(epochs, verbose=verbose),
-            batch_size=min(train_X.get_L(), batch_size),
             optimizer=optax.adamw(
                 optax.warmup_cosine_decay_schedule(
                     1e-8, lr, 5 * steps_per_epoch, epochs * steps_per_epoch, 1e-7
                 ),
                 weight_decay=1e-5,
             ),
-            validation_X=val_X,
-            validation_Y=val_Y,
+            val_dataloader=val_dataloader,
             val_map_and_loss=ml.Mapper([geom.Losses.NRMSE], residual, eps=1e-5),
             aux_data=batch_stats,
             is_wandb=is_wandb,
@@ -408,15 +401,16 @@ def train_model(
             ml.save_plus(model_path, trained_model, {"train_time": train_time})
 
     assert trained_model is not None
-    if images_dir and val_X.D == 2:
+    if images_dir and D == 2:
+        val_x_one, val_y_one = next(iter(val_dataloader))
         pred_y, _ = ml.Mapper([geom.Losses.NRMSE], residual).map(
-            trained_model, val_X.get_one(), batch_stats
+            trained_model, val_x_one, batch_stats
         )
         plot_multi_image(
-            val_X.get_one(),
-            val_Y.get_one(),
+            val_x_one,
+            val_y_one,
             pred_y.get_one(),
-            f"{images_dir}{model_name_extended}_D{val_X.D}.png",
+            f"{images_dir}{model_name_extended}_D{D}.png",
             "burgers",
         )
 
@@ -424,12 +418,7 @@ def train_model(
 
 
 def train_all_models(
-    data: tuple[
-        geom.MultiImage,
-        geom.MultiImage,
-        geom.MultiImage,
-        geom.MultiImage,
-    ],
+    data: tuple[DataLoader[ml.MultiImageDataset], DataLoader[ml.MultiImageDataset]],
     key: jax.Array,
     model_list: list[tuple[str, dict, dict]],
     lr_range: list[float],
@@ -447,7 +436,9 @@ def train_all_models(
     returns:
         list of tuples of (model_name, tune_and_eval, test_kwargs, train_time)
     """
-    train_D = data[0].D
+    train_dataloader, _ = data
+    assert isinstance(train_dataloader.dataset, ml.MultiImageDataset)
+    train_D = train_dataloader.dataset.D
 
     trained_models = []
     for model_name, _train_kwargs, _test_kwargs in model_list:
@@ -456,7 +447,7 @@ def train_all_models(
         if args.find_train_lr:
 
             def train_f(data, subkey, name, **kwargs):
-                train_model(data, subkey, name, **kwargs)
+                train_model(data, name, **kwargs)
                 return 1.0  # train model returns the model, but benchmark expects a float
 
             ml.benchmark_lr(
@@ -477,7 +468,7 @@ def train_all_models(
                 },
             )
         else:
-            trained_model, train_time = train_model(data, subkey, model_name, **_train_kwargs)
+            trained_model, train_time = train_model(data, model_name, **_train_kwargs)
             _test_kwargs = {**_test_kwargs, "model": trained_model}
             trained_models.append((model_name, tune_and_eval, _test_kwargs, train_time))
 
@@ -486,12 +477,9 @@ def train_all_models(
 
 def tune_and_eval(
     data: tuple[
-        geom.MultiImage,
-        geom.MultiImage,
-        geom.MultiImage,
-        geom.MultiImage,
-        geom.MultiImage,
-        geom.MultiImage,
+        DataLoader[ml.MultiImageDataset],
+        DataLoader[ml.MultiImageDataset],
+        DataLoader[ml.MultiImageDataset],
     ],
     key: jax.Array,
     model_name: str,
@@ -539,20 +527,24 @@ def tune_and_eval(
     returns:
         tuple of smse_mean, smse_std, relative error mean, relative error std, tuning time
     """
-    tune_X, tune_Y, val_X, val_Y, test_X, test_Y = data
-    N = tune_X.get_spatial_dims()[0]
+    tune_dataloader, val_dataloader, test_dataloader = data
+    assert isinstance(tune_dataloader.dataset, ml.MultiImageDataset)
+
+    tune_D = tune_dataloader.dataset.D
+    L = len(tune_dataloader.dataset)
+    N = tune_dataloader.dataset.get_N()
     batch_stats = eqx.nn.State(model) if has_aux else None
-    model_name_extended = f"{model_name}_tuneD{tune_X.D}_L{tune_X.get_L()}_N{N}_e{epochs}"
+    model_name_extended = f"{model_name}_tuneD{tune_D}_L{L}_N{N}_e{epochs}"
 
     key, subkey = random.split(key)
     # rescale set to True, small but notable difference
     if conv_filters_dict is not None and rescale is not None:
         start_time = time.time()
         model_dprime = model.convertD(
-            conv_filters_dict[tune_X.D],
+            conv_filters_dict[tune_D],
             rescale,
             subkey,
-            upsample_filters=upsample_filters_dict[tune_X.D] if upsample_filters_dict else None,
+            upsample_filters=upsample_filters_dict[tune_D] if upsample_filters_dict else None,
         )
         convert_time = time.time() - start_time  # this should be tiny
         model_name_extended += f"_rescale{rescale.name}"
@@ -568,26 +560,22 @@ def tune_and_eval(
         tune_time = further_args["train_time"]
         tune_batch_stats = batch_stats
     else:
-        if tune_X.get_L() > 0:
+        if L > 0:
             # Now treat the trained_model_d as a warmstart and do some additional training
             key, subkey = random.split(key)
-            steps_per_epoch = int(math.ceil(tune_X.get_L() / batch_size))
-            tuned_model_dprime, tune_batch_stats, _, _, tune_time = ml.train(
-                tune_X,
-                tune_Y,
+            steps_per_epoch = int(math.ceil(L / batch_size))
+            tuned_model_dprime, tune_batch_stats, _, _, tune_time = ml.train_dl(
+                tune_dataloader,
                 ml.Mapper([train_loss_f], residual, eps=1e-9),
                 model_dprime,
-                subkey,
                 stop_condition=ml.EpochStop(epochs, verbose=verbose),
-                batch_size=min(tune_X.get_L(), batch_size),
                 optimizer=optax.adamw(
                     optax.warmup_cosine_decay_schedule(
                         1e-8, lr, 5 * steps_per_epoch, epochs * steps_per_epoch, 1e-7
                     ),
                     weight_decay=1e-5,
                 ),
-                validation_X=val_X,
-                validation_Y=val_Y,
+                val_dataloader=val_dataloader,
                 val_map_and_loss=ml.Mapper([geom.Losses.NRMSE], residual, eps=1e-9),
                 aux_data=batch_stats,
                 is_wandb=is_wandb,
@@ -603,13 +591,10 @@ def tune_and_eval(
 
     key, subkey = random.split(key)
     # (batch,losses)
-    tuned_loss = ml.map_loss_in_batches(
+    tuned_loss = ml.map_loss_in_batches_dl(
         ml.Mapper([geom.Losses.L2_REL, geom.Losses.SMSE], residual, reduce=None, eps=1e-9),
         tuned_model_dprime,
-        test_X,
-        test_Y,
-        batch_size,
-        subkey,
+        test_dataloader,
         aux_data=tune_batch_stats,
         reduce=None,
     )
@@ -618,7 +603,7 @@ def tune_and_eval(
     smse_mean = jnp.mean(tuned_loss[:, 1])
     smse_std = jnp.std(tuned_loss[:, 1])
     print(
-        f"Tuned Loss rescale=True, D={test_X.D}: {smse_mean:.3e} +-{smse_std:.3e} ({rel_mean:.3f}% +-{rel_std:.3f}%)\n"
+        f"Tuned Loss rescale=True, D={tune_D}: {smse_mean:.3e} +-{smse_std:.3e} ({rel_mean:.3f}% +-{rel_std:.3f}%)\n"
     )
 
     return smse_mean, smse_std, rel_mean, rel_std, convert_time + tune_time
@@ -633,12 +618,9 @@ def run_anyd(
     get_data: Callable[
         [int, int, int, int, jax.Array],
         tuple[
-            geom.MultiImage,
-            geom.MultiImage,
-            geom.MultiImage,
-            geom.MultiImage,
-            geom.MultiImage,
-            geom.MultiImage,
+            DataLoader[ml.MultiImageDataset],
+            DataLoader[ml.MultiImageDataset],
+            DataLoader[ml.MultiImageDataset],
             float,
         ],
     ],
@@ -664,11 +646,11 @@ def run_anyd(
     pretrain_data_time_d = {}
     for train_D in train_D_range:
         key, subkey = random.split(key)
-        train_x0, train_xt, val_x0, val_xt, _, _, pretrain_data_time = get_data(
-            train_D, args.n_train, args.n_val, 0, subkey
+        train_dataloader, val_dataloader, _, pretrain_data_time = get_data(
+            train_D, args.n_train, args.n_val, 1, subkey
         )
 
-        train_data = (train_x0, train_xt, val_x0, val_xt)
+        train_data = (train_dataloader, val_dataloader)
         key, subkey = random.split(key)
         trained_model_list_d[train_D] = train_all_models(
             train_data, subkey, model_list_d[train_D], lr_range, args
@@ -687,6 +669,7 @@ def run_anyd(
             print(f"D={test_D}, n_tune={n_tune}.\n")
             # the data is saved, so this is still reasonably efficient
             key, subkey = random.split(key)
+            # TODO: as n_tune grows, it may later include data points that were used for val/test
             *tune_data, tune_data_time = get_data(test_D, n_tune, args.n_val, args.n_test, subkey)
 
             # need to train the baseline model on tune_x0, etc. aka models without the warmstart
@@ -699,11 +682,11 @@ def run_anyd(
                         "lr": _train_kwargs["lr"][test_D][n_tune],
                         "conv_filters_dict": None,
                         "rescale": None,
-                        "is_wandb": args.tune_wandb,
-                        "batch_size": args.batch_size,
+                        "is_wandb": _test_kwargs["is_wandb"],
+                        "batch_size": _test_kwargs["batch_size"],
                     },
                 )
-                for name, _train_kwargs, _ in model_list_d[test_D]
+                for name, _train_kwargs, _test_kwargs in model_list_d[test_D]
             ]
 
             key, subkey = random.split(key)

--- a/scripts/anyd_helpers.py
+++ b/scripts/anyd_helpers.py
@@ -647,7 +647,7 @@ def run_anyd(
     for train_D in train_D_range:
         key, subkey = random.split(key)
         train_dataloader, val_dataloader, _, pretrain_data_time = get_data(
-            train_D, args.n_train, args.n_val, 1, subkey
+            train_D, args.n_train, args.n_val, 0, subkey
         )
 
         train_data = (train_dataloader, val_dataloader)

--- a/scripts/anyd_helpers.py
+++ b/scripts/anyd_helpers.py
@@ -700,6 +700,7 @@ def run_anyd(
                         "conv_filters_dict": None,
                         "rescale": None,
                         "is_wandb": args.tune_wandb,
+                        "batch_size": args.batch_size,
                     },
                 )
                 for name, _train_kwargs, _ in model_list_d[test_D]

--- a/scripts/burgers_anyd.py
+++ b/scripts/burgers_anyd.py
@@ -9,6 +9,7 @@ import jax
 import jax.numpy as jnp
 from jax import random
 import apebench
+from torch.utils.data import BatchSampler, DataLoader, RandomSampler, SequentialSampler
 
 import ginjax.geometric as geom
 from ginjax import models
@@ -180,15 +181,13 @@ def get_data(
     n_train: int,
     n_val: int,
     n_test: int,
+    batch_size: int,
     key: jax.Array,
     data_dir: str,
 ) -> tuple[
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
     float,
 ]:
     """
@@ -203,6 +202,7 @@ def get_data(
         n_train: train dataset size
         n_val: validation dataset size
         n_test: test dataset size
+        batch_size: the training batch size
         key: jax key for randomness
         data_dir: director to save/load the data
 
@@ -223,6 +223,14 @@ def get_data(
         subkey1,
         data_dir_path / "train",
     )
+    train_dataset = ml.MultiImageDataset(train_x0, train_xt)
+    # RandomSampler breaks if the dataset is empty
+    sampler = RandomSampler(train_dataset) if n_train > 0 else SequentialSampler(train_dataset)
+    train_dataloader = DataLoader(
+        train_dataset,
+        sampler=BatchSampler(sampler, batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
+    )
 
     val_x0, val_xt, _ = get_data_d(
         D,
@@ -234,6 +242,12 @@ def get_data(
         n_val,
         subkey2,
         data_dir_path / "val",
+    )
+    val_dataset = ml.MultiImageDataset(val_x0, val_xt)
+    val_dataloader = DataLoader(
+        val_dataset,
+        sampler=BatchSampler(SequentialSampler(val_dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
     )
 
     test_x0, test_xt, _ = get_data_d(
@@ -247,12 +261,18 @@ def get_data(
         subkey3,
         data_dir_path / "test",
     )
+    test_dataset = ml.MultiImageDataset(test_x0, test_xt)
+    test_dataloader = DataLoader(
+        test_dataset,
+        sampler=BatchSampler(SequentialSampler(test_dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
+    )
 
-    return train_x0, train_xt, val_x0, val_xt, test_x0, test_xt, train_data_time
+    return train_dataloader, val_dataloader, test_dataloader, train_data_time
 
 
 # Something like
-# CUDA_VISIBLE_DEVICES=0,1 time python3 scripts/burgers_anyd.py --data /data/wgregor4/apebench/burgers/
+# CUDA_VISIBLE_DEVICES=0,1 time python3 -m scripts.burgers_anyd --data /data/wgregor4/apebench/burgers/
 # --n-train 8 --n-val 8 --n-test 8 --batch 2 --model-dir /data/wgregor4/runs/burgers_anyd/
 def handleArgs() -> argparse.Namespace:
     parser = utils.get_common_parser()
@@ -407,7 +427,7 @@ print("Define the models!")
 model_list_d = {}
 for D in full_D_range:
     key, subkey = random.split(key)
-    train_x0, train_xt, _, _, _, _, _ = get_data(
+    train_x0, train_xt, _ = get_data_d(
         D,
         args.N,
         args.diffusion_coef,
@@ -415,10 +435,8 @@ for D in full_D_range:
         args.n_timesteps,
         args.subsample,
         args.n_train,
-        0,
-        0,
         subkey,
-        args.data,
+        pathlib.Path(args.data) / "train",
     )
     input_keys = train_x0.get_signature()
     output_keys = train_xt.get_signature()
@@ -537,12 +555,9 @@ for D in full_D_range:
 
 # extended lambda function
 def get_data_lambda(D: int, n_train: int, n_val: int, n_test: int, key: jax.Array) -> tuple[
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
     float,
 ]:
     return get_data(
@@ -555,6 +570,7 @@ def get_data_lambda(D: int, n_train: int, n_val: int, n_test: int, key: jax.Arra
         n_train,
         n_val,
         n_test,
+        args.batch,
         key,
         args.data,
     )

--- a/scripts/cfd_anyd.py
+++ b/scripts/cfd_anyd.py
@@ -37,12 +37,15 @@ def read_one_h5(
     pressure = jax.device_put(
         jnp.array(data_dict["pressure"][traj_idxs][()]), jax.devices("cpu")[0]
     )
-    # (batch,2,timesteps,spatial)
-    density_pressure = jnp.concatenate([density[:, None], pressure[:, None]], axis=1)
-    # (batch,2*timesteps,spatial)
-    density_pressure = density_pressure.reshape(
-        (len(density_pressure), -1) + density_pressure.shape[3:]
-    )
+    if len(density) == 0:
+        density_pressure = jnp.zeros((0, 2 * density.shape[1]) + density.shape[2:])
+    else:
+        # (batch,2,timesteps,spatial)
+        density_pressure = jnp.concatenate([density[:, None], pressure[:, None]], axis=1)
+        # (batch,2*timesteps,spatial)
+        density_pressure = density_pressure.reshape(
+            (len(density_pressure), -1) + density_pressure.shape[3:]
+        )
 
     velocities = []
     for vkey in ["Vx", "Vy", "Vz"][:D]:
@@ -68,9 +71,8 @@ def read_one_h5(
 def open_hdf5(D: int, data_dir: str) -> h5py.File:
     data_dir_path = pathlib.Path(data_dir)
     fnames = {
-        1: "1D_CFD_Rand_Eta0.01_Zeta0.01_periodic_Train.hdf5",
-        2: "2D_CFD_Rand_M0.1_Eta1e-08_Zeta1e-08_periodic_128_Train.hdf5",
-        3: "3D_CFD_Rand_M0.1_Eta1e-08_Zeta1e-08_periodic_Train.hdf5",
+        2: "2D_CFD_Rand_M0.1_Eta1e-08_Zeta1e-08_periodic_64_Train.hdf5",
+        3: "3D_CFD_Rand_M0.1_Eta1e-08_Zeta1e-08_periodic_64_Train.hdf5",
     }
     return h5py.File(data_dir_path / f"cfd_{D}d" / fnames[D])
 
@@ -198,12 +200,7 @@ def get_data(
     past_steps: int,
     batch_size: int,
     data_dir: str,
-) -> tuple[
-    DataLoader[CFDDataset],
-    DataLoader[CFDDataset],
-    DataLoader[CFDDataset],
-    float,
-]:
+) -> tuple[DataLoader[CFDDataset], DataLoader[CFDDataset], DataLoader[CFDDataset], float]:
     """
     TODO: maybe I can load data as needed? one batch at a time? probably needed for 3d data
     Get data of a particular dimension from a preset list of files in the specified folder.
@@ -232,9 +229,11 @@ def get_data(
     else:
         raise ValueError(f"cfd_anyd::get_data: expects D=2,3, but got D={D}")
 
+    # RandomSampler requires __len__ > 0
+    sampler = RandomSampler(train_dataset) if n_train > 0 else SequentialSampler(train_dataset)
     train_dataloader = DataLoader(
         train_dataset,
-        sampler=BatchSampler(RandomSampler(train_dataset), batch_size, drop_last=True),
+        sampler=BatchSampler(sampler, batch_size, drop_last=True),
         collate_fn=lambda x: x[0],
     )
     val_dataloader = DataLoader(
@@ -371,20 +370,45 @@ for D in full_D_range:
 
     key, *subkeys = random.split(key, num=10)
     model_list = [
+        # (
+        #     f"unetBase_equiv48_D{D}",
+        #     {  # train_kwargs
+        #         "model": models.UNet(
+        #             D,
+        #             input_keys,
+        #             output_keys,
+        #             depth=48,
+        #             activation_f=jax.nn.gelu,
+        #             conv_filters=free_filters_dict[D],
+        #             upsample_filters=upsample_filters_dict[D],
+        #             key=subkeys[2],
+        #         ),
+        #         "lr": {2: {128: 1e-4}, 3: {0: 1e-4, 1: 1e-4, 4: 1e-4, 32: 1e-4, 128: 1e-4}},
+        #         # D=3, for all of them (and tuning) its just 1e-4
+        #         **train_kwargs,
+        #     },
+        #     {  # tune and eval kwargs
+        #         "lr": {(2, 3): {0: 1e-4, 1: 1e-4, 4: 1e-4, 32: 1e-4, 128: 1e-4}},
+        #         "rescale": geom.Rescaling.COMPAT_FLEX,
+        #         "conv_filters_dict": free_filters_dict,
+        #         "upsample_filters_dict": upsample_filters_dict,
+        #         **test_kwargs,
+        #     },
+        # ),
         (
-            f"unetBase_equiv48_D{D}",
+            f"unetBase_equiv20_D{D}",
             {  # train_kwargs
                 "model": models.UNet(
                     D,
                     input_keys,
                     output_keys,
-                    depth=48,
+                    depth=20,
                     activation_f=jax.nn.gelu,
                     conv_filters=free_filters_dict[D],
                     upsample_filters=upsample_filters_dict[D],
-                    key=subkeys[2],
+                    key=subkeys[3],
                 ),
-                "lr": {2: {128: 1e-4}, 3: {0: 1e-4, 1: 1e-4, 4: 1e-4, 32: 1e-4, 128: 1e-4}},
+                "lr": {2: {128: 5e-4}, 3: {0: 1e-4, 1: 1e-4, 4: 1e-4, 32: 1e-4, 128: 1e-4}},
                 # D=3, for all of them (and tuning) its just 1e-4
                 **train_kwargs,
             },
@@ -402,9 +426,9 @@ for D in full_D_range:
 
 # extended lambda function
 def get_data_lambda(D: int, n_train: int, n_val: int, n_test: int, key: jax.Array) -> tuple[
-    DataLoader[ml.MultiImageDataset],
-    DataLoader[ml.MultiImageDataset],
-    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset] | None,
+    DataLoader[ml.MultiImageDataset] | None,
+    DataLoader[ml.MultiImageDataset] | None,
     float,
 ]:
     return get_data(

--- a/scripts/cfd_anyd.py
+++ b/scripts/cfd_anyd.py
@@ -1,20 +1,26 @@
-import time
 import argparse
-import pathlib
 import h5py
+import numpy as np
+import pathlib
+import time
+from typing_extensions import Self
 
 import jax.numpy as jnp
 import jax
 import jax.random as random
+from torch.utils.data import BatchSampler, DataLoader, RandomSampler, SequentialSampler
 
 import ginjax.geometric as geom
 import ginjax.utils as utils
 import ginjax.data as gc_data
 import ginjax.models as models
+import ginjax.ml as ml
 from . import anyd_helpers
 
 
-def read_one_h5(D: int, filename: pathlib.Path, num_trajectories: int) -> tuple:
+def read_one_h5(
+    D: int, is_torus: bool, past_steps: int, data_dict: h5py.File, traj_idxs: np.ndarray | slice
+) -> tuple[geom.MultiImage, geom.MultiImage]:
     """
     Given a dimension and filename, read the data and return as jax arrays.
 
@@ -26,31 +32,162 @@ def read_one_h5(D: int, filename: pathlib.Path, num_trajectories: int) -> tuple:
     returns:
         density, pressure, and velocity fields
     """
-    data_dict = h5py.File(filename)
+    density = jax.device_put(jnp.array(data_dict["density"][traj_idxs][()]), jax.devices("cpu")[0])
 
-    # all of these are shape (num_trajectories, timesteps, spatial, tensor)
-    # 1D: (10K,101,1024,tensor)
-    # 2D: (1K,21,512,512,tensor) or (10K,21,128,128,tensor)
-    # 2D: my janky homebrew is (9990,21,128,128,tensor)
-    # 3D: (100,21,128,128,128,tensor)
-    density = jax.device_put(
-        jnp.array(data_dict["density"][:num_trajectories][()]), jax.devices("cpu")[0]
-    )
     pressure = jax.device_put(
-        jnp.array(data_dict["pressure"][:num_trajectories][()]), jax.devices("cpu")[0]
+        jnp.array(data_dict["pressure"][traj_idxs][()]), jax.devices("cpu")[0]
+    )
+    # (batch,2,timesteps,spatial)
+    density_pressure = jnp.concatenate([density[:, None], pressure[:, None]], axis=1)
+    # (batch,2*timesteps,spatial)
+    density_pressure = density_pressure.reshape(
+        (len(density_pressure), -1) + density_pressure.shape[3:]
     )
 
     velocities = []
     for vkey in ["Vx", "Vy", "Vz"][:D]:
         velocities.append(
-            jax.device_put(jnp.array(data_dict[vkey][:num_trajectories][()]), jax.devices("cpu")[0])
+            jax.device_put(jnp.array(data_dict[vkey][traj_idxs][()]), jax.devices("cpu")[0])
         )
 
     velocity = jnp.stack(velocities, axis=-1)
 
-    data_dict.close()
+    constant_fields = geom.MultiImage({}, D, is_torus)
 
-    return density, pressure, velocity
+    X, Y = gc_data.batch_time_series(
+        geom.MultiImage({(0, 0): density_pressure, (1, 0): velocity}, D, is_torus),
+        constant_fields,
+        velocity.shape[1],
+        past_steps,
+        1,
+    )
+
+    return X, Y
+
+
+def open_hdf5(D: int, data_dir: str) -> h5py.File:
+    data_dir_path = pathlib.Path(data_dir)
+    fnames = {
+        1: "1D_CFD_Rand_Eta0.01_Zeta0.01_periodic_Train.hdf5",
+        2: "2D_CFD_Rand_M0.1_Eta1e-08_Zeta1e-08_periodic_128_Train.hdf5",
+        3: "3D_CFD_Rand_M0.1_Eta1e-08_Zeta1e-08_periodic_Train.hdf5",
+    }
+    return h5py.File(data_dir_path / f"cfd_{D}d" / fnames[D])
+
+
+class CFDDataset(ml.MultiImageDataset):
+    """
+    A datset to load the cfd data. This dataset loads all the data into memory, then takes a subset
+    during __call__. The only difference between this and ml.MultiImageDataset is how it handles
+    the CFD data specifically in the constructor.
+
+    The __getitem__ for this class expects a list of integer indices for the entire batch at
+    once, which means the sampler of the data loader should be a batch sampler.
+    """
+
+    def __init__(
+        self: Self,
+        D: int,
+        n_data: int,
+        idx_shift: int,
+        past_steps: int,
+        data_dir: str,
+        devices: list[jax.Device] | None = None,
+        use_devices: bool = True,
+        is_torus: bool = True,
+    ) -> None:
+        self.D = D
+
+        data_dict = open_hdf5(D, data_dir)
+        X, Y = read_one_h5(D, is_torus, past_steps, data_dict, slice(idx_shift, idx_shift + n_data))
+        data_dict.close()
+
+        self.X = X
+        self.Y = Y
+
+        self.devices = devices if devices else jax.devices()
+        self.use_devices = use_devices
+
+
+class CFDDatasetLazy(ml.MultiImageDataset):
+    """
+    A dataset to lazily load cfd data.
+
+    The __getitem__ for this class expects a list of integer indices for the entire batch at
+    once, which means the sampler of the data loader should be a batch sampler.
+    """
+
+    D: int
+    n_data: int
+    idx_shift: int
+    past_steps: int
+    samples_per_traj: int
+    data_dict: h5py.File
+    devices: list[jax.Device]
+    use_devices: bool
+    is_torus: bool
+
+    def __init__(
+        self: Self,
+        D: int,
+        n_data: int,
+        idx_shift: int,
+        past_steps: int,
+        data_dir: str,
+        devices: list[jax.Device] | None = None,
+        use_devices: bool = True,
+        is_torus: bool = True,
+    ) -> None:
+        self.D = D
+        self.n_data = n_data
+        self.idx_shift = idx_shift
+        self.past_steps = past_steps
+        self.samples_per_traj = 21 - args.past_steps
+
+        self.data_dict = open_hdf5(D, data_dir)
+
+        self.devices = devices if devices else jax.devices()
+        self.use_devices = use_devices
+        self.is_torus = is_torus
+
+    def __len__(self: Self) -> int:
+        return self.n_data * self.samples_per_traj
+
+    def __getitem__(self: Self, idx: list[int]) -> tuple[geom.MultiImage, geom.MultiImage]:
+        # all of these are shape (num_trajectories, timesteps, spatial, tensor)
+        # 1D: (10K,101,1024,tensor)
+        # 2D: (1K,21,512,512,tensor) or (10K,21,128,128,tensor)
+        # 2D: my janky homebrew is (9990,21,128,128,tensor)
+        # 3D: (100,21,128,128,128,tensor)
+
+        # TODO: may be a way to do this better with a memory mask
+
+        idxs = np.sort(np.array(idx))
+        shifted_idxs = idxs + self.idx_shift * self.samples_per_traj
+
+        # select only the trajectories that we need
+        # get the idxs and counts of the trajectories, e.g. [14,15,35,171] -> [0,2,11], [2,1,1]
+        traj_idxs, idxs_counts = np.unique(
+            shifted_idxs // self.samples_per_traj, return_counts=True
+        )
+
+        X, Y = read_one_h5(self.D, self.is_torus, self.past_steps, self.data_dict, traj_idxs)
+
+        # get the row numbers of loaded data, e.g. [14,15,35,171] -> [0,0,1,2]
+        row_numbers = np.repeat(np.arange(len(traj_idxs)), idxs_counts)
+        # get the corrected full indices [14,15,35,171] % 17 + [0,0,1,2]*17
+        samples_idxs = idxs % self.samples_per_traj + row_numbers * self.samples_per_traj
+        samples_idxs = jnp.array(samples_idxs)
+
+        X, Y = X.get_subset(samples_idxs), Y.get_subset(samples_idxs)
+
+        if self.use_devices:
+            X, Y = X.reshape_pmap(self.devices), Y.reshape_pmap(self.devices)
+
+        return X, Y
+
+    def get_N(self: Self) -> int:
+        return self.data_dict["density"].shape[2]
 
 
 def get_data(
@@ -59,14 +196,12 @@ def get_data(
     n_val: int,
     n_test: int,
     past_steps: int,
+    batch_size: int,
     data_dir: str,
 ) -> tuple[
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
+    DataLoader[CFDDataset],
+    DataLoader[CFDDataset],
+    DataLoader[CFDDataset],
     float,
 ]:
     """
@@ -79,82 +214,43 @@ def get_data(
         n_val: number of validation trajectories
         n_test: number of test trajectories
         past_steps: number of historical steps to use to predict the next 1 step
+        batch_size: the batch size
         data_dir: the direcory where the data is stored
 
     returns:
         input and output pairs of multi images for train, val, and test, plus data generation time
             for train
     """
-    data_dir_path = pathlib.Path(data_dir)
-    is_torus = True
-
-    fnames = {
-        1: "1D_CFD_Rand_Eta0.01_Zeta0.01_periodic_Train.hdf5",
-        2: "2D_CFD_Rand_M0.1_Eta1e-08_Zeta1e-08_periodic_128_Train.hdf5",
-        3: "3D_CFD_Rand_M0.1_Eta1e-08_Zeta1e-08_periodic_Train.hdf5",
-    }
-
-    fpath = data_dir_path / f"cfd_{D}d" / fnames[D]
-    n_traj = n_train + n_val + n_test
-
-    density, pressure, velocity = read_one_h5(D, fpath, n_traj)
-
-    constant_fields = geom.MultiImage({}, D, is_torus)
-
-    # (batch,2,timesteps,spatial)
-    if n_traj == 0:
-        density_pressure = jnp.zeros((n_traj, 2 * density.shape[1]) + density.shape[2:])
+    if D == 2:
+        train_dataset = CFDDataset(D, n_train, 0, past_steps, data_dir)
+        val_dataset = CFDDataset(D, n_val, n_train, past_steps, data_dir)
+        test_dataset = CFDDataset(D, n_test, n_train + n_test, past_steps, data_dir)
+    elif D == 3:
+        train_dataset = CFDDatasetLazy(D, n_train, 0, past_steps, data_dir)
+        val_dataset = CFDDatasetLazy(D, n_val, n_train, past_steps, data_dir)
+        test_dataset = CFDDatasetLazy(D, n_test, n_train + n_test, past_steps, data_dir)
     else:
-        density_pressure = jnp.concatenate([density[:, None], pressure[:, None]], axis=1)
-        # (batch,2*timesteps,spatial)
-        density_pressure = density_pressure.reshape(
-            (len(density_pressure), -1) + density_pressure.shape[3:]
-        )
+        raise ValueError(f"cfd_anyd::get_data: expects D=2,3, but got D={D}")
 
-    start = 0
-    stop = n_train
-    train_X, train_Y = gc_data.batch_time_series(
-        geom.MultiImage(
-            {(0, 0): density_pressure[start:stop], (1, 0): velocity[start:stop]},
-            D,
-            is_torus,
-        ),
-        constant_fields,
-        velocity.shape[1],
-        past_steps,
-        1,
+    train_dataloader = DataLoader(
+        train_dataset,
+        sampler=BatchSampler(RandomSampler(train_dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
     )
-
-    start = start + n_train
-    stop = start + n_val
-    val_X, val_Y = gc_data.batch_time_series(
-        geom.MultiImage(
-            {(0, 0): density_pressure[start:stop], (1, 0): velocity[start:stop]},
-            D,
-            is_torus,
-        ),
-        constant_fields,
-        velocity.shape[1],
-        past_steps,
-        1,
+    val_dataloader = DataLoader(
+        val_dataset,
+        sampler=BatchSampler(SequentialSampler(val_dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
     )
-
-    start = start + n_val
-    stop = start + n_test
-
-    test_X, test_Y = gc_data.batch_time_series(
-        geom.MultiImage(
-            {(0, 0): density_pressure[start:stop], (1, 0): velocity[start:stop]}, D, is_torus
-        ),
-        constant_fields,
-        velocity.shape[1],
-        past_steps,
-        1,
+    test_dataloader = DataLoader(
+        test_dataset,
+        sampler=BatchSampler(SequentialSampler(test_dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
     )
 
     data_generation_time = 0.0  # TODO: fix this
 
-    return train_X, train_Y, val_X, val_Y, test_X, test_Y, data_generation_time
+    return train_dataloader, val_dataloader, test_dataloader, data_generation_time
 
 
 def handleArgs() -> argparse.Namespace:
@@ -168,6 +264,8 @@ def handleArgs() -> argparse.Namespace:
     parser.add_argument(
         "--past-steps", help="number of past steps to use as input", type=int, default=4
     )
+    parser.add_argument("--batch-train", help="batch size for 2D training", type=int, default=32)
+    parser.add_argument("--batch-tune", help="batch size for 3D tuning", type=int, default=2)
     parser.add_argument(
         "--find-train-lr",
         help="benchmark trained model over the lr",
@@ -219,8 +317,7 @@ n_results = 5
 train_kwargs = {
     "train_loss_f": geom.Losses.NRMSE,
     "residual": False,
-    # "batch_size": args.batch,
-    "batch_size": 32,
+    "batch_size": args.batch_train,
     "epochs": args.epochs,
     "model_dir": pathlib.Path(args.model_dir) if args.model_dir else None,
     "overwrite_save_model": args.overwrite_save_model,
@@ -232,7 +329,7 @@ train_kwargs = {
 test_kwargs = {
     "train_loss_f": geom.Losses.NRMSE,
     "residual": False,
-    "batch_size": args.batch,
+    "batch_size": args.batch_tune,
     "epochs": args.epochs,
     "model_dir": pathlib.Path(args.model_dir) if args.model_dir else None,
     "overwrite_save_model": args.overwrite_save_model,
@@ -268,7 +365,7 @@ print("Define the models!")
 model_list_d = {}
 for D in full_D_range:
     key, subkey = random.split(key)
-    train_x0, train_xt, _, _, _, _, _ = get_data(D, 1, 0, 0, args.past_steps, args.data)
+    train_x0, train_xt = CFDDataset(D, 1, 0, args.past_steps, args.data, use_devices=False)[[0]]
     input_keys = train_x0.get_signature()
     output_keys = train_xt.get_signature()
 
@@ -305,15 +402,20 @@ for D in full_D_range:
 
 # extended lambda function
 def get_data_lambda(D: int, n_train: int, n_val: int, n_test: int, key: jax.Array) -> tuple[
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
     float,
 ]:
-    return get_data(D, n_train, n_val, n_test, args.past_steps, args.data)
+    return get_data(
+        D,
+        n_train,
+        n_val,
+        n_test,
+        args.past_steps,
+        args.batch_train if D == 2 else args.batch_tune,
+        args.data,
+    )
 
 
 key, subkey = random.split(key)

--- a/scripts/cfd_anyd.py
+++ b/scripts/cfd_anyd.py
@@ -219,7 +219,8 @@ n_results = 5
 train_kwargs = {
     "train_loss_f": geom.Losses.NRMSE,
     "residual": False,
-    "batch_size": args.batch,
+    # "batch_size": args.batch,
+    "batch_size": 32,
     "epochs": args.epochs,
     "model_dir": pathlib.Path(args.model_dir) if args.model_dir else None,
     "overwrite_save_model": args.overwrite_save_model,

--- a/scripts/heat_equation.py
+++ b/scripts/heat_equation.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 import argparse
 import math
-import matplotlib.pyplot as plt
-from matplotlib.axes import Axes
-import numpy as np
 import pathlib
 import time
 
 import jax
 import jax.numpy as jnp
 import jax.random as random
+from torch.utils.data import BatchSampler, DataLoader, RandomSampler, SequentialSampler
 
 import ginjax.geometric as geom
 import ginjax.ml as ml
@@ -131,15 +129,13 @@ def get_data(
     n_train: int,
     n_val: int,
     n_test: int,
+    batch_size: int,
     key: jax.Array,
     data_dir: str,
 ) -> tuple[
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
     float,
 ]:
     """
@@ -154,6 +150,7 @@ def get_data(
         n_train: number of training data points
         n_val: number of validation data points
         n_test: number of test data points for each test dimension
+        batch_size: the training batch size
         key: key for randomness
         data_dir: location to save or load the data from
 
@@ -168,26 +165,47 @@ def get_data(
     train_x0, train_xt, train_generation_time = get_data_d(
         D, N, is_torus, diffusion_coef, t, max_temp, n_train, subkey1, data_dir_path / "train"
     )
+    train_dataset = ml.MultiImageDataset(train_x0, train_xt)
+    # RandomSampler breaks if the dataset is empty
+    sampler = RandomSampler(train_dataset) if n_train > 0 else SequentialSampler(train_dataset)
+    train_dataloader = DataLoader(
+        train_dataset,
+        sampler=BatchSampler(sampler, batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
+    )
 
     val_x0, val_xt, _ = get_data_d(
         D, N, is_torus, diffusion_coef, t, max_temp, n_val, subkey2, data_dir_path / "val"
+    )
+    val_dataset = ml.MultiImageDataset(val_x0, val_xt)
+    val_dataloader = DataLoader(
+        val_dataset,
+        sampler=BatchSampler(SequentialSampler(val_dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
     )
 
     test_x0, test_xt, _ = get_data_d(
         D, N, is_torus, diffusion_coef, t, max_temp, n_test, subkey3, data_dir_path / "test"
     )
+    test_dataset = ml.MultiImageDataset(test_x0, test_xt)
+    test_dataloader = DataLoader(
+        test_dataset,
+        sampler=BatchSampler(SequentialSampler(test_dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
+    )
+
     if n_test > 0:
         x0_std = jnp.std(test_x0[((), 0)])
         xt_std = jnp.std(test_xt[((), 0)])
         xt_resid_std = jnp.std(test_xt[((), 0)] - test_x0[((), 0)])
         print(f"D={D}, x0:{x0_std:.3e}, xt:{xt_std:.3e}, xt_resid:{xt_resid_std:.3e}")
 
-    return train_x0, train_xt, val_x0, val_xt, test_x0, test_xt, train_generation_time
+    return train_dataloader, val_dataloader, test_dataloader, train_generation_time
 
 
 # an example of currently used script
 # CUDA_VISIBLE_DEVICES=6 time python3 -m scripts.heat_equation --data /data/wgregor4/heat_equation/
-# --n-test 128 --n-val 128 --n-train 128 --train-D-range 1,2 --test-D-range 2,3
+# --n-test 128 --n-val 128 --n-train 128 --train-D-range 1 --test-D-range 2
 # --model-dir /data/wgregor4/runs/heat_equation/
 def handleArgs() -> argparse.Namespace:
     parser = utils.get_common_parser()
@@ -352,8 +370,16 @@ print("Define the models!")
 model_list_d = {}
 for D in full_D_range:
     key, subkey = random.split(key)
-    train_x0, train_xt, _, _, _, _, _ = get_data(
-        D, args.N, True, args.diffusion_coef, args.n_train, 0, 0, subkey, args.data
+    train_x0, train_xt, _ = get_data_d(
+        D,
+        args.N,
+        True,
+        args.diffusion_coef,
+        1,
+        math.sqrt(3),
+        args.n_train,
+        subkey,
+        pathlib.Path(args.data) / "train",
     )
     input_keys = train_x0.get_signature()
     output_keys = train_xt.get_signature()
@@ -576,15 +602,14 @@ for D in full_D_range:
 
 # extended lambda function
 def get_data_lambda(D: int, n_train: int, n_val: int, n_test: int, key: jax.Array) -> tuple[
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
-    geom.MultiImage,
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
+    DataLoader[ml.MultiImageDataset],
     float,
 ]:
-    return get_data(D, args.N, True, args.diffusion_coef, n_train, n_val, n_test, key, args.data)
+    return get_data(
+        D, args.N, True, args.diffusion_coef, n_train, n_val, n_test, args.batch, key, args.data
+    )
 
 
 key, subkey = random.split(key)

--- a/src/ginjax/geometric/multi_image.py
+++ b/src/ginjax/geometric/multi_image.py
@@ -1136,16 +1136,3 @@ class MultiImage:
         Helper function to define GeometricImage as a pytree so jax.jit handles it correctly.
         """
         return cls(*children, **aux_data)
-
-
-def concat(multi_images: Sequence[MultiImage]) -> MultiImage:
-    """
-    Concatenate a list of multi images into a single multi image. This implicitly assumes that all
-    images are of the same type.
-    """
-    assert len(multi_images) > 0, "concat: Must be at least one multi image."
-    first = multi_images[0]
-    data = jnp.concat([image.to_scalar_multi_image()[((), 0)] for image in multi_images])
-    return MultiImage(
-        {((), 0): data}, first.D, first.is_torus, first.metric_tensor, first.metric_tensor_inv
-    ).from_scalar_multi_image(first.get_signature())

--- a/src/ginjax/geometric/multi_image.py
+++ b/src/ginjax/geometric/multi_image.py
@@ -1136,3 +1136,16 @@ class MultiImage:
         Helper function to define GeometricImage as a pytree so jax.jit handles it correctly.
         """
         return cls(*children, **aux_data)
+
+
+def concat(multi_images: Sequence[MultiImage]) -> MultiImage:
+    """
+    Concatenate a list of multi images into a single multi image. This implicitly assumes that all
+    images are of the same type.
+    """
+    assert len(multi_images) > 0, "concat: Must be at least one multi image."
+    first = multi_images[0]
+    data = jnp.concat([image.to_scalar_multi_image()[((), 0)] for image in multi_images])
+    return MultiImage(
+        {((), 0): data}, first.D, first.is_torus, first.metric_tensor, first.metric_tensor_inv
+    ).from_scalar_multi_image(first.get_signature())

--- a/src/ginjax/ml/training.py
+++ b/src/ginjax/ml/training.py
@@ -15,6 +15,7 @@ import jax.random as random
 from jax.typing import ArrayLike
 import equinox as eqx
 import optax
+from torch.utils.data import Dataset, DataLoader
 
 import ginjax.geometric as geom
 from ginjax.ml.stopping_conditions import StopCondition, ValLoss
@@ -93,6 +94,34 @@ def load_plus(
 
 
 ## Data and Batching operations
+
+
+class MultiImageDataset(Dataset):
+    """
+    A basic dataset for multi images which assumes that we already have the X and Y in memory.
+    """
+
+    X: geom.MultiImage
+    Y: geom.MultiImage
+
+    def __init__(self: Self, X: geom.MultiImage, Y: geom.MultiImage) -> None:
+        self.X = X
+        self.Y = Y
+
+    def __len__(self: Self) -> int:
+        return self.X.get_L()
+
+    def __getitem__(self: Self, idx: int) -> tuple[geom.MultiImage, geom.MultiImage]:
+        return self.X.get_one(idx), self.Y.get_one(idx)
+
+
+def collate_multi_images(
+    multi_images: list[tuple[geom.MultiImage, geom.MultiImage]],
+) -> tuple[geom.MultiImage, geom.MultiImage]:
+    assert len(multi_images) > 0, "collate_multi_image: The list is empty."
+
+    X, Y = list(zip(*multi_images))  # unzip list into all the inputs and all the outputs
+    return geom.concat(X), geom.concat(Y)
 
 
 def get_batches(
@@ -305,6 +334,44 @@ def multi_image_reducer(ls: list[geom.MultiImage]) -> geom.MultiImage:
     return functools.reduce(lambda carry, val: carry.concat(val), ls, ls[0].empty())
 
 
+def map_loss_in_batches_dl(
+    map_and_loss: Callable[
+        [models.MultiImageModule, geom.MultiImage, geom.MultiImage, eqx.nn.State | None],
+        tuple[jax.Array, eqx.nn.State | None],
+    ],
+    model: models.MultiImageModule,
+    dataloader: DataLoader,
+    devices: list[jax.Device] | None = None,
+    aux_data: eqx.nn.State | None = None,
+    reduce: str | None = "mean",
+) -> jax.Array:
+    """
+    Runs map_and_loss for the entire x, y, splitting into batches if the MultiImage is larger than
+    the batch_size. This is helpful to run a whole validation/test set through map and loss when you need
+    to split those over batches for memory reasons. Automatically pmaps over multiple gpus, so the number
+    of gpus must evenly divide batch_size as well as as any remainder of the MultiImage.
+
+    args:
+        map_and_loss: function that takes in model, X_batch, Y_batch, and
+            aux_data and returns the loss and aux_data
+        model: the model to run through map_and_loss
+        dataloader: the dataloader for input and output multi image data
+        devices: the gpus that the code will run on
+        aux_data: auxilliary data, such as batch stats. Passed to the function is has_aux is True.
+        reduce: how to reduce between batches, defaults to mean
+
+    Returns:
+        Average loss over the entire BatchMultiImage
+    """
+    losses = []
+    for X_batch, Y_batch in dataloader:
+        X_batch = X_batch.reshape_pmap(devices)
+        Y_batch = Y_batch.reshape_pmap(devices)
+        losses.append(evaluate(model, map_and_loss, X_batch, Y_batch, aux_data, False))
+
+    return loss_reducer(losses) if reduce == "mean" else jnp.concat(losses, axis=0)
+
+
 def map_loss_in_batches(
     map_and_loss: Callable[
         [models.MultiImageModule, geom.MultiImage, geom.MultiImage, Optional[eqx.nn.State]],
@@ -340,14 +407,9 @@ def map_loss_in_batches(
     Returns:
         Average loss over the entire BatchMultiImage
     """
-    X_batches, Y_batches = get_batches((x, y), batch_size, rand_key, devices)
-    losses = [
-        evaluate(model, map_and_loss, X_batch, Y_batch, aux_data, False)
-        for X_batch, Y_batch in zip(X_batches, Y_batches)
-    ]
-    # because return_map=False, losses is a list of jax arrays
-
-    return loss_reducer(losses) if reduce == "mean" else jnp.concat(losses, axis=0)
+    dataset = MultiImageDataset(x, y)
+    dataloader = DataLoader(dataset, batch_size, shuffle=False, collate_fn=collate_multi_images)
+    return map_loss_in_batches_dl(map_and_loss, model, dataloader, devices, aux_data, reduce)
 
 
 def map_plus_loss_in_batches(
@@ -445,20 +507,16 @@ def train_step(
     return model, opt_state, loss, aux_data
 
 
-def train(
-    X: geom.MultiImage,
-    Y: geom.MultiImage,
+def train_dl(
+    train_dataloader: DataLoader,
     map_and_loss: Callable[
-        [models.MultiImageModule, geom.MultiImage, geom.MultiImage, Optional[eqx.nn.State]],
-        tuple[jax.Array, Optional[eqx.nn.State]],
+        [models.MultiImageModule, geom.MultiImage, geom.MultiImage, eqx.nn.State | None],
+        tuple[jax.Array, eqx.nn.State | None],
     ],
     model: models.MultiImageModule,
-    rand_key: ArrayLike,
     stop_condition: StopCondition,
-    batch_size: int,
     optimizer: optax.GradientTransformation,
-    validation_X: Optional[geom.MultiImage] = None,
-    validation_Y: Optional[geom.MultiImage] = None,
+    val_dataloader: DataLoader | None = None,
     val_map_and_loss: (
         Callable[
             [models.MultiImageModule, geom.MultiImage, geom.MultiImage, eqx.nn.State | None],
@@ -466,9 +524,9 @@ def train(
         ]
         | None
     ) = None,
-    save_model: Optional[str] = None,
-    devices: Optional[list[jax.Device]] = None,
-    aux_data: Optional[eqx.nn.State] = None,
+    save_model: str | None = None,
+    devices: list[jax.Device] | None = None,
+    aux_data: eqx.nn.State | None = None,
     is_wandb: bool = False,
 ) -> tuple[models.MultiImageModule, eqx.nn.State | None, ArrayLike | None, ArrayLike | None, float]:
     """
@@ -476,6 +534,128 @@ def train(
     parameters the minimize the map_and_loss function. The model is returned. This function automatically
     pmaps over the available gpus, so batch_size should be divisible by the number of gpus. If you only want
     to train on a single GPU, the script should be run with CUDA_VISIBLE_DEVICES=# for whatever gpu number.
+    This version uses pytorch datasets and dataloaders.
+
+    args:
+        dataset: the input and target data as a MultImageDataset. Each is a MultiImage by k of
+            (images, channels, (N,)*D, (D,)*k)
+        map_and_loss: function that takes in model, X_batch, Y_batch, and aux_data and
+            returns the loss and aux_data.
+        model: Model pytree
+        rand_key: key for randomness
+        stop_condition: when to stop the training process, currently only 1 condition
+            at a time
+        batch_size: the size of each mini-batch in SGD
+        optimizer: optimizer
+        val_dataset: the input and target data as a MultImageDataset. Each is a MultiImage by k of
+            (images, channels, (N,)*D, (D,)*k)
+        save_model: if string, save model every 10 epochs, defaults to None
+        aux_data: initial aux data passed in to map_and_loss when has_aux is true.
+        devices: gpu/cpu devices to use, if None (default) then it will use jax.devices()
+        is_wandb: whether wandb experiment tracking has been initiated and should be logged to
+
+    returns:
+        A tuple of best model in inference mode, aux_data, epoch loss, val loss, and train_time
+    """
+    if isinstance(stop_condition, ValLoss) and val_dataloader is None:
+        raise ValueError("Stop condition is ValLoss, but no validation data provided.")
+
+    if val_map_and_loss is None:
+        val_map_and_loss = map_and_loss
+
+    devices = devices if devices else jax.devices()
+
+    total_train_time = 0
+    opt_state = optimizer.init(eqx.filter(model, eqx.is_array))
+    epoch = 0
+    epoch_val_loss = None
+    epoch_loss = None
+    val_loss = None
+    epoch_time = 0
+    stop_condition.best_model = model
+    while not stop_condition.stop(model, epoch, epoch_loss, epoch_val_loss, epoch_time):
+        start_time = time.time()
+        epoch_loss = None
+        n_batches = 0
+        for X_batch, Y_batch in train_dataloader:  # TODO: check, this should go through 1 epoch?
+            n_batches += 1
+            X_batch = X_batch.reshape_pmap(devices)
+            Y_batch = Y_batch.reshape_pmap(devices)
+            model, opt_state, loss_value, aux_data = train_step(
+                map_and_loss,
+                model,
+                optimizer,
+                opt_state,
+                X_batch,
+                Y_batch,
+                aux_data,
+            )
+            epoch_loss = loss_value if epoch_loss is None else epoch_loss + loss_value
+
+        total_train_time += time.time() - start_time
+        print("n_batches", n_batches)
+
+        if epoch_loss is not None:
+            epoch_loss = epoch_loss / n_batches
+
+        epoch += 1
+        log = {"train/loss": epoch_loss}
+
+        # We evaluate the validation loss in batches for memory reasons.
+        if val_dataloader is not None:
+            epoch_val_loss = map_loss_in_batches_dl(
+                val_map_and_loss,
+                model,
+                val_dataloader,
+                devices=devices,
+                aux_data=aux_data,
+            )
+            val_loss = epoch_val_loss
+            log["val/loss"] = val_loss
+
+        if is_wandb:
+            wandb.log(log)
+
+        if save_model and ((epoch % 10) == 0):
+            save(save_model, model)
+
+        epoch_time = time.time() - start_time
+
+    return stop_condition.best_model, aux_data, epoch_loss, val_loss, total_train_time
+
+
+def train(
+    X: geom.MultiImage,
+    Y: geom.MultiImage,
+    map_and_loss: Callable[
+        [models.MultiImageModule, geom.MultiImage, geom.MultiImage, eqx.nn.State | None],
+        tuple[jax.Array, eqx.nn.State | None],
+    ],
+    model: models.MultiImageModule,
+    rand_key: jax.Array,
+    stop_condition: StopCondition,
+    batch_size: int,
+    optimizer: optax.GradientTransformation,
+    validation_X: geom.MultiImage | None = None,
+    validation_Y: geom.MultiImage | None = None,
+    val_map_and_loss: (
+        Callable[
+            [models.MultiImageModule, geom.MultiImage, geom.MultiImage, eqx.nn.State | None],
+            tuple[jax.Array, eqx.nn.State | None],
+        ]
+        | None
+    ) = None,
+    save_model: str | None = None,
+    devices: list[jax.Device] | None = None,
+    aux_data: eqx.nn.State | None = None,
+    is_wandb: bool = False,
+) -> tuple[models.MultiImageModule, eqx.nn.State | None, ArrayLike | None, ArrayLike | None, float]:
+    """
+    Method to train the model. It uses stochastic gradient descent (SGD) with the optimizer to learn the
+    parameters the minimize the map_and_loss function. The model is returned. This function automatically
+    pmaps over the available gpus, so batch_size should be divisible by the number of gpus. If you only want
+    to train on a single GPU, the script should be run with CUDA_VISIBLE_DEVICES=# for whatever gpu number.
+    Use train_dl if you would like to pass pytorch dataloaders.
 
     args:
         X: The X input data as a MultiImage by k of (images, channels, (N,)*D, (D,)*k)
@@ -500,71 +680,32 @@ def train(
     returns:
         A tuple of best model in inference mode, aux_data, epoch loss, val loss, and train_time
     """
-    if isinstance(stop_condition, ValLoss) and not (validation_X and validation_Y):
-        raise ValueError("Stop condition is ValLoss, but no validation data provided.")
+    train_dataset = MultiImageDataset(X, Y)
+    train_dataloader = DataLoader(
+        train_dataset, batch_size, shuffle=True, collate_fn=collate_multi_images
+    )
 
-    if val_map_and_loss is None:
-        val_map_and_loss = map_and_loss
+    if validation_X is not None and validation_Y is not None:
+        val_dataset = MultiImageDataset(validation_X, validation_Y)
+        val_dataloader = DataLoader(
+            val_dataset, batch_size, shuffle=False, collate_fn=collate_multi_images
+        )
+    else:
+        val_dataloader = None
 
-    devices = devices if devices else jax.devices()
-
-    total_train_time = 0
-    opt_state = optimizer.init(eqx.filter(model, eqx.is_array))
-    epoch = 0
-    epoch_val_loss = None
-    epoch_loss = None
-    val_loss = None
-    epoch_time = 0
-    stop_condition.best_model = model
-    while not stop_condition.stop(model, epoch, epoch_loss, epoch_val_loss, epoch_time):
-        start_time = time.time()
-        rand_key, subkey = random.split(rand_key)
-        X_batches, Y_batches = get_batches((X, Y), batch_size, subkey, devices)
-        epoch_loss = None
-        for X_batch, Y_batch in zip(X_batches, Y_batches):
-            model, opt_state, loss_value, aux_data = train_step(
-                map_and_loss,
-                model,
-                optimizer,
-                opt_state,
-                X_batch,
-                Y_batch,
-                aux_data,
-            )
-            epoch_loss = loss_value if epoch_loss is None else epoch_loss + loss_value
-
-        total_train_time += time.time() - start_time
-
-        if epoch_loss is not None:
-            epoch_loss = epoch_loss / len(X_batches)
-
-        epoch += 1
-        log = {"train/loss": epoch_loss}
-
-        # We evaluate the validation loss in batches for memory reasons.
-        if validation_X and validation_Y:
-            epoch_val_loss = map_loss_in_batches(
-                val_map_and_loss,
-                model,
-                validation_X,
-                validation_Y,
-                batch_size,
-                subkey,
-                devices=devices,
-                aux_data=aux_data,
-            )
-            val_loss = epoch_val_loss
-            log["val/loss"] = val_loss
-
-        if is_wandb:
-            wandb.log(log)
-
-        if save_model and ((epoch % 10) == 0):
-            save(save_model, model)
-
-        epoch_time = time.time() - start_time
-
-    return stop_condition.best_model, aux_data, epoch_loss, val_loss, total_train_time
+    return train_dl(
+        train_dataloader,
+        map_and_loss,
+        model,
+        stop_condition,
+        optimizer,
+        val_dataloader,
+        val_map_and_loss,
+        save_model,
+        devices,
+        aux_data,
+        is_wandb,
+    )
 
 
 BENCHMARK_DATA = "benchmark_data"

--- a/src/ginjax/ml/training.py
+++ b/src/ginjax/ml/training.py
@@ -587,7 +587,7 @@ def train_dl(
         start_time = time.time()
         epoch_loss = None
         n_batches = 0
-        for X_batch, Y_batch in train_dataloader:  # TODO: check, this should go through 1 epoch?
+        for X_batch, Y_batch in train_dataloader:
             n_batches += 1
             model, opt_state, loss_value, aux_data = train_step(
                 map_and_loss,

--- a/src/ginjax/ml/training.py
+++ b/src/ginjax/ml/training.py
@@ -15,7 +15,7 @@ import jax.random as random
 from jax.typing import ArrayLike
 import equinox as eqx
 import optax
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import BatchSampler, DataLoader, Dataset, RandomSampler, SequentialSampler
 
 import ginjax.geometric as geom
 from ginjax.ml.stopping_conditions import StopCondition, ValLoss
@@ -99,29 +99,44 @@ def load_plus(
 class MultiImageDataset(Dataset):
     """
     A basic dataset for multi images which assumes that we already have the X and Y in memory.
+    The __getitem__ for this class expects a list of integer indices for the entire batch at
+    once, which means the sampler of the data loader should be a batch sampler.
     """
 
+    D: int
     X: geom.MultiImage
     Y: geom.MultiImage
+    devices: list[jax.Device]
+    use_devices: bool
 
-    def __init__(self: Self, X: geom.MultiImage, Y: geom.MultiImage) -> None:
+    def __init__(
+        self: Self,
+        X: geom.MultiImage,
+        Y: geom.MultiImage,
+        devices: list[jax.Device] | None = None,
+        use_devices: bool = True,
+    ) -> None:
+        self.D = X.D
         self.X = X
         self.Y = Y
+        self.devices = devices if devices else jax.devices()
+        self.use_devices = use_devices
 
     def __len__(self: Self) -> int:
         return self.X.get_L()
 
-    def __getitem__(self: Self, idx: int) -> tuple[geom.MultiImage, geom.MultiImage]:
-        return self.X.get_one(idx), self.Y.get_one(idx)
+    def __getitem__(self: Self, idx: list[int]) -> tuple[geom.MultiImage, geom.MultiImage]:
+        idxs = jnp.array(idx)
+        X_batch, Y_batch = self.X.get_subset(idxs), self.Y.get_subset(idxs)
 
+        if self.use_devices:
+            X_batch = X_batch.reshape_pmap(self.devices)
+            Y_batch = Y_batch.reshape_pmap(self.devices)
 
-def collate_multi_images(
-    multi_images: list[tuple[geom.MultiImage, geom.MultiImage]],
-) -> tuple[geom.MultiImage, geom.MultiImage]:
-    assert len(multi_images) > 0, "collate_multi_image: The list is empty."
+        return X_batch, Y_batch
 
-    X, Y = list(zip(*multi_images))  # unzip list into all the inputs and all the outputs
-    return geom.concat(X), geom.concat(Y)
+    def get_N(self: Self) -> int:
+        return self.X.get_spatial_dims()[0]
 
 
 def get_batches(
@@ -341,7 +356,6 @@ def map_loss_in_batches_dl(
     ],
     model: models.MultiImageModule,
     dataloader: DataLoader,
-    devices: list[jax.Device] | None = None,
     aux_data: eqx.nn.State | None = None,
     reduce: str | None = "mean",
 ) -> jax.Array:
@@ -356,7 +370,6 @@ def map_loss_in_batches_dl(
             aux_data and returns the loss and aux_data
         model: the model to run through map_and_loss
         dataloader: the dataloader for input and output multi image data
-        devices: the gpus that the code will run on
         aux_data: auxilliary data, such as batch stats. Passed to the function is has_aux is True.
         reduce: how to reduce between batches, defaults to mean
 
@@ -365,8 +378,6 @@ def map_loss_in_batches_dl(
     """
     losses = []
     for X_batch, Y_batch in dataloader:
-        X_batch = X_batch.reshape_pmap(devices)
-        Y_batch = Y_batch.reshape_pmap(devices)
         losses.append(evaluate(model, map_and_loss, X_batch, Y_batch, aux_data, False))
 
     return loss_reducer(losses) if reduce == "mean" else jnp.concat(losses, axis=0)
@@ -407,9 +418,13 @@ def map_loss_in_batches(
     Returns:
         Average loss over the entire BatchMultiImage
     """
-    dataset = MultiImageDataset(x, y)
-    dataloader = DataLoader(dataset, batch_size, shuffle=False, collate_fn=collate_multi_images)
-    return map_loss_in_batches_dl(map_and_loss, model, dataloader, devices, aux_data, reduce)
+    dataset = MultiImageDataset(x, y, devices)
+    dataloader = DataLoader(
+        dataset,
+        sampler=BatchSampler(SequentialSampler(dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
+    )
+    return map_loss_in_batches_dl(map_and_loss, model, dataloader, aux_data, reduce)
 
 
 def map_plus_loss_in_batches(
@@ -525,7 +540,6 @@ def train_dl(
         | None
     ) = None,
     save_model: str | None = None,
-    devices: list[jax.Device] | None = None,
     aux_data: eqx.nn.State | None = None,
     is_wandb: bool = False,
 ) -> tuple[models.MultiImageModule, eqx.nn.State | None, ArrayLike | None, ArrayLike | None, float]:
@@ -537,21 +551,19 @@ def train_dl(
     This version uses pytorch datasets and dataloaders.
 
     args:
-        dataset: the input and target data as a MultImageDataset. Each is a MultiImage by k of
+        train_dataloader: dataloader for train input and target data. Each is a MultiImage by k of
             (images, channels, (N,)*D, (D,)*k)
         map_and_loss: function that takes in model, X_batch, Y_batch, and aux_data and
             returns the loss and aux_data.
         model: Model pytree
-        rand_key: key for randomness
         stop_condition: when to stop the training process, currently only 1 condition
             at a time
         batch_size: the size of each mini-batch in SGD
         optimizer: optimizer
-        val_dataset: the input and target data as a MultImageDataset. Each is a MultiImage by k of
+        val_dataloader: dataloader for val input and target data. Each is a MultiImage by k of
             (images, channels, (N,)*D, (D,)*k)
         save_model: if string, save model every 10 epochs, defaults to None
         aux_data: initial aux data passed in to map_and_loss when has_aux is true.
-        devices: gpu/cpu devices to use, if None (default) then it will use jax.devices()
         is_wandb: whether wandb experiment tracking has been initiated and should be logged to
 
     returns:
@@ -562,8 +574,6 @@ def train_dl(
 
     if val_map_and_loss is None:
         val_map_and_loss = map_and_loss
-
-    devices = devices if devices else jax.devices()
 
     total_train_time = 0
     opt_state = optimizer.init(eqx.filter(model, eqx.is_array))
@@ -579,8 +589,6 @@ def train_dl(
         n_batches = 0
         for X_batch, Y_batch in train_dataloader:  # TODO: check, this should go through 1 epoch?
             n_batches += 1
-            X_batch = X_batch.reshape_pmap(devices)
-            Y_batch = Y_batch.reshape_pmap(devices)
             model, opt_state, loss_value, aux_data = train_step(
                 map_and_loss,
                 model,
@@ -593,7 +601,6 @@ def train_dl(
             epoch_loss = loss_value if epoch_loss is None else epoch_loss + loss_value
 
         total_train_time += time.time() - start_time
-        print("n_batches", n_batches)
 
         if epoch_loss is not None:
             epoch_loss = epoch_loss / n_batches
@@ -607,7 +614,6 @@ def train_dl(
                 val_map_and_loss,
                 model,
                 val_dataloader,
-                devices=devices,
                 aux_data=aux_data,
             )
             val_loss = epoch_val_loss
@@ -680,15 +686,19 @@ def train(
     returns:
         A tuple of best model in inference mode, aux_data, epoch loss, val loss, and train_time
     """
-    train_dataset = MultiImageDataset(X, Y)
+    train_dataset = MultiImageDataset(X, Y, devices)
     train_dataloader = DataLoader(
-        train_dataset, batch_size, shuffle=True, collate_fn=collate_multi_images
+        train_dataset,
+        sampler=BatchSampler(RandomSampler(train_dataset), batch_size, drop_last=True),
+        collate_fn=lambda x: x[0],
     )
 
     if validation_X is not None and validation_Y is not None:
-        val_dataset = MultiImageDataset(validation_X, validation_Y)
+        val_dataset = MultiImageDataset(validation_X, validation_Y, devices)
         val_dataloader = DataLoader(
-            val_dataset, batch_size, shuffle=False, collate_fn=collate_multi_images
+            val_dataset,
+            sampler=BatchSampler(SequentialSampler(val_dataset), batch_size, drop_last=True),
+            collate_fn=lambda x: x[0],
         )
     else:
         val_dataloader = None
@@ -702,7 +712,6 @@ def train(
         val_dataloader,
         val_map_and_loss,
         save_model,
-        devices,
         aux_data,
         is_wandb,
     )


### PR DESCRIPTION
## Changes
- added a train_dl and map_loss_in_batches_dl functions to handle dataloaders
- anyd_helpers now expects dataloaders
- update burgers, heat_equation, and cfd_anyd to use dataloaders
- define a lazy loading cfd dataset to use for D==3 when we only want to load the batch into cpu memory
- set separate batch_tune and batch_train for cfd, may want to do this in burgers as well?
- swap to unet_equiv20 in cfd so 3d model fits in memory
- default MultiImageDataset in training that expects the data to already be loaded into memory

## Testing
- run burgers, heat_equation, and cfd_anyd

## Doc Changes
- should probably update the read the docs at some point to note that we can now use dataloaders, still somewhat experimental though